### PR TITLE
Add Index to Names

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -2,10 +2,11 @@ package fluentbit_config
 
 import (
 	"fmt"
-	"github.com/alecthomas/participle/v2"
-	"github.com/alecthomas/participle/v2/lexer"
 	"regexp"
 	"strings"
+
+	"github.com/alecthomas/participle/v2"
+	"github.com/alecthomas/participle/v2/lexer"
 )
 
 var (
@@ -62,14 +63,19 @@ type Value struct {
 }
 
 type Config struct {
-	Inputs  map[string][]Field
-	Filters map[string][]Field
-	Customs map[string][]Field
-	Outputs map[string][]Field
-	Parsers map[string][]Field
+	Inputs      map[string][]Field
+	Filters     map[string][]Field
+	Customs     map[string][]Field
+	Outputs     map[string][]Field
+	Parsers     map[string][]Field
+	InputIndex  int
+	FilterIndex int
+	OutputIndex int
+	CustomIndex int
+	ParserIndex int
 }
 
-func addFields(e *Entry, m *map[string][]Field) {
+func addFields(e *Entry, index int, m *map[string][]Field) {
 	if *m == nil {
 		*m = map[string][]Field{}
 	}
@@ -82,7 +88,7 @@ func addFields(e *Entry, m *map[string][]Field) {
 	}
 
 	for _, field := range e.Section.Fields {
-		q[name] = append(q[name], *field)
+		q[fmt.Sprintf("%s.%d", name, index)] = append(q[fmt.Sprintf("%s.%d", name, index)], *field)
 	}
 }
 
@@ -91,23 +97,28 @@ func (c *Config) loadSectionsFromGrammar(grammar *ConfigGrammar) error {
 		switch entry.Section.Name {
 		case "INPUT":
 			{
-				addFields(entry, &c.Inputs)
+				addFields(entry, c.InputIndex, &c.Inputs)
+				c.InputIndex++
 			}
 		case "FILTER":
 			{
-				addFields(entry, &c.Filters)
+				addFields(entry, c.FilterIndex, &c.Filters)
+				c.FilterIndex++
 			}
 		case "OUTPUT":
 			{
-				addFields(entry, &c.Outputs)
+				addFields(entry, c.OutputIndex, &c.Outputs)
+				c.OutputIndex++
 			}
 		case "CUSTOM":
 			{
-				addFields(entry, &c.Customs)
+				addFields(entry, c.CustomIndex, &c.Customs)
+				c.CustomIndex++
 			}
 		case "PARSER":
 			{
-				addFields(entry, &c.Parsers)
+				addFields(entry, c.ParserIndex, &c.Parsers)
+				c.ParserIndex++
 			}
 		}
 	}

--- a/parser.go
+++ b/parser.go
@@ -83,12 +83,12 @@ func addFields(e *Entry, index int, m *map[string][]Field) {
 	var name string
 	for _, field := range e.Section.Fields {
 		if strings.ToLower(field.Key) == "name" {
-			name = *field.Value.String
+			name = fmt.Sprintf("%s.%d", *field.Value.String, index)
 		}
 	}
 
 	for _, field := range e.Section.Fields {
-		q[fmt.Sprintf("%s.%d", name, index)] = append(q[fmt.Sprintf("%s.%d", name, index)], *field)
+		q[name] = append(q[name], *field)
 	}
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -8,6 +8,10 @@ func stringPtr(s string) *string {
 	return &s
 }
 
+func numberPtr(n float64) *float64 {
+	return &n
+}
+
 func TestNewConfigFromBytes(t *testing.T) {
 	tt := []struct {
 		name          string
@@ -22,11 +26,16 @@ func TestNewConfigFromBytes(t *testing.T) {
 				"@@"
 			`),
 			expected: struct {
-				Inputs  map[string][]Field
-				Filters map[string][]Field
-				Customs map[string][]Field
-				Outputs map[string][]Field
-				Parsers map[string][]Field
+				Inputs      map[string][]Field
+				Filters     map[string][]Field
+				Customs     map[string][]Field
+				Outputs     map[string][]Field
+				Parsers     map[string][]Field
+				InputIndex  int
+				FilterIndex int
+				OutputIndex int
+				CustomIndex int
+				ParserIndex int
 			}{Inputs: map[string][]Field{}, Filters: map[string][]Field{}, Customs: map[string][]Field{}, Outputs: map[string][]Field{}, Parsers: map[string][]Field{}},
 			expectedError: true,
 		},
@@ -34,11 +43,16 @@ func TestNewConfigFromBytes(t *testing.T) {
 			name:   "test invalid configuration",
 			config: []byte(""),
 			expected: struct {
-				Inputs  map[string][]Field
-				Filters map[string][]Field
-				Customs map[string][]Field
-				Outputs map[string][]Field
-				Parsers map[string][]Field
+				Inputs      map[string][]Field
+				Filters     map[string][]Field
+				Customs     map[string][]Field
+				Outputs     map[string][]Field
+				Parsers     map[string][]Field
+				InputIndex  int
+				FilterIndex int
+				OutputIndex int
+				CustomIndex int
+				ParserIndex int
 			}{Inputs: map[string][]Field{}, Filters: map[string][]Field{}, Customs: map[string][]Field{}, Outputs: map[string][]Field{}, Parsers: map[string][]Field{}},
 			expectedError: true,
 		},
@@ -56,14 +70,19 @@ func TestNewConfigFromBytes(t *testing.T) {
 					Time_Key time
 					Time_Format %d/%b/%Y:%H:%M:%S %z`),
 			expected: struct {
-				Inputs  map[string][]Field
-				Filters map[string][]Field
-				Customs map[string][]Field
-				Outputs map[string][]Field
-				Parsers map[string][]Field
+				Inputs      map[string][]Field
+				Filters     map[string][]Field
+				Customs     map[string][]Field
+				Outputs     map[string][]Field
+				Parsers     map[string][]Field
+				InputIndex  int
+				FilterIndex int
+				OutputIndex int
+				CustomIndex int
+				ParserIndex int
 			}{
 				Parsers: map[string][]Field{
-					"apache2": []Field{
+					"apache2.0": []Field{
 						{
 							Key: "Name", Value: &Value{
 								String:   stringPtr("apache2"),
@@ -90,7 +109,7 @@ func TestNewConfigFromBytes(t *testing.T) {
 						},
 					},
 				},
-				Inputs: map[string][]Field{"tail": []Field{
+				Inputs: map[string][]Field{"tail.0": []Field{
 					{Key: "name", Value: &Value{
 						String:   stringPtr("tail"),
 						DateTime: nil,
@@ -136,13 +155,18 @@ func TestNewConfigFromBytes(t *testing.T) {
 					bucket your-bucket
 			`),
 			expected: struct {
-				Inputs  map[string][]Field
-				Filters map[string][]Field
-				Customs map[string][]Field
-				Outputs map[string][]Field
-				Parsers map[string][]Field
+				Inputs      map[string][]Field
+				Filters     map[string][]Field
+				Customs     map[string][]Field
+				Outputs     map[string][]Field
+				Parsers     map[string][]Field
+				InputIndex  int
+				FilterIndex int
+				OutputIndex int
+				CustomIndex int
+				ParserIndex int
 			}{
-				Inputs: map[string][]Field{"tail": []Field{
+				Inputs: map[string][]Field{"tail.0": []Field{
 					{Key: "name", Value: &Value{
 						String:   stringPtr("tail"),
 						DateTime: nil,
@@ -176,7 +200,7 @@ func TestNewConfigFromBytes(t *testing.T) {
 				}},
 				Filters: map[string][]Field{},
 				Customs: map[string][]Field{},
-				Outputs: map[string][]Field{"s3": []Field{
+				Outputs: map[string][]Field{"s3.0": []Field{
 					{Key: "name", Value: &Value{
 						String:   stringPtr("s3"),
 						DateTime: nil,
@@ -199,6 +223,129 @@ func TestNewConfigFromBytes(t *testing.T) {
 					}},
 					{Key: "bucket", Value: &Value{
 						String:   stringPtr("your-bucket"),
+						DateTime: nil,
+						Date:     nil,
+						Time:     nil,
+						Bool:     nil,
+						Number:   nil,
+						Float:    nil,
+						List:     nil,
+					}},
+				}},
+				Parsers: map[string][]Field{},
+			},
+			expectedError: false,
+		},
+		{
+			name: "test valid larger configuration",
+			config: []byte(`
+				[INPUT]
+					Name tcp
+					Port 5556
+					Tag  foobar
+
+				[INPUT]
+					Name tcp
+					Port 5557
+					Tag  foobat
+
+				[OUTPUT]
+					Name  stdout
+					Match *
+			`),
+			expected: struct {
+				Inputs      map[string][]Field
+				Filters     map[string][]Field
+				Customs     map[string][]Field
+				Outputs     map[string][]Field
+				Parsers     map[string][]Field
+				InputIndex  int
+				FilterIndex int
+				OutputIndex int
+				CustomIndex int
+				ParserIndex int
+			}{
+				Inputs: map[string][]Field{
+					"tcp.0": {
+						{Key: "Name", Value: &Value{
+							String:   stringPtr("tcp"),
+							DateTime: nil,
+							Date:     nil,
+							Time:     nil,
+							Bool:     nil,
+							Number:   nil,
+							Float:    nil,
+							List:     nil,
+						}},
+						{Key: "Port", Value: &Value{
+							String:   nil,
+							DateTime: nil,
+							Date:     nil,
+							Time:     nil,
+							Bool:     nil,
+							Number:   numberPtr(5556),
+							Float:    nil,
+							List:     nil,
+						}},
+						{Key: "Tag", Value: &Value{
+							String:   stringPtr("foobar"),
+							DateTime: nil,
+							Date:     nil,
+							Time:     nil,
+							Bool:     nil,
+							Number:   nil,
+							Float:    nil,
+							List:     nil,
+						}},
+					},
+					"tcp.1": {
+						{Key: "Name", Value: &Value{
+							String:   stringPtr("tcp"),
+							DateTime: nil,
+							Date:     nil,
+							Time:     nil,
+							Bool:     nil,
+							Number:   nil,
+							Float:    nil,
+							List:     nil,
+						}},
+						{Key: "Port", Value: &Value{
+							String:   nil,
+							DateTime: nil,
+							Date:     nil,
+							Time:     nil,
+							Bool:     nil,
+							Number:   numberPtr(5557),
+							Float:    nil,
+							List:     nil,
+						}},
+						{Key: "Tag", Value: &Value{
+							String:   stringPtr("foobat"),
+							DateTime: nil,
+							Date:     nil,
+							Time:     nil,
+							Bool:     nil,
+							Number:   nil,
+							Float:    nil,
+							List:     nil,
+						}},
+					},
+				},
+				Filters: map[string][]Field{},
+				Customs: map[string][]Field{},
+				Outputs: map[string][]Field{"stdout.0": []Field{
+					{Key: "name", Value: &Value{
+						String:   stringPtr("stdout"),
+						DateTime: nil,
+						Date:     nil,
+						Time:     nil,
+						Bool:     nil,
+						Number:   nil,
+						Float:    nil,
+						List:     nil,
+					}},
+					{Key: "Match", Value: &Value{
+						String:   stringPtr("*"),
 						DateTime: nil,
 						Date:     nil,
 						Time:     nil,


### PR DESCRIPTION
Add an index to the name for inputs, filters, outputs, parsers and custom entries.

Add an index which is unique to each of filters, outputs, parsers and custom
sections to reproduce the behavior of fluent-bit and allow multiple
definitions for each plugin. This is related to problems I saw when the
duplicate port bug occured.
