### PR TITLE
Support for JSON intermediary format

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -2,6 +2,7 @@ package fluentbit_config
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -292,14 +293,6 @@ func ParseINI(data []byte) (*Config, error) {
 	return &config, nil
 }
 
-type yamlGrammarPipeline struct {
-	Inputs  []map[string]Fields `yaml:"inputs"`
-	Filters []map[string]Fields `yaml:"filters,omitempty"`
-	Parsers []map[string]Fields `yaml:"parsers,omitempty"`
-	Outputs []map[string]Fields `yaml:"outputs"`
-	Customs []map[string]Fields `yaml:"customs,omitempty"`
-}
-
 type Fields []Field
 
 func (fs *Fields) UnmarshalYAML(unmarshal func(v interface{}) error) error {
@@ -366,9 +359,82 @@ func (fs Fields) MarshalYAML() (interface{}, error) {
 	return fmap, nil
 }
 
+func (fs *Fields) UnmarshalJSON(raw []byte) error {
+	panic("FOO FIGHTORZ")
+	kv := make(map[string]interface{})
+	if err := json.Unmarshal(raw, &kv); err != nil {
+		return err
+	}
+	fields := make([]Field, 0)
+	for k, v := range kv {
+		if k == "name" {
+			continue
+		}
+		switch v.(type) {
+		case string:
+			str := v.(string)
+			fields = append(fields, Field{
+				Key: k,
+				Values: []*Value{{
+					String: &str,
+				}},
+			})
+		case int:
+			i := v.(int)
+			f := float64(i)
+			fields = append(fields, Field{
+				Key: k,
+				Values: []*Value{{
+					Number: &f,
+				}},
+			})
+		default:
+			return fmt.Errorf("unknown type: %+v", v)
+		}
+	}
+	*fs = fields
+
+	return nil
+}
+
+func (fs Fields) MarshalJSON() ([]byte, error) {
+	fmap := make(map[string]interface{})
+	for _, field := range fs {
+		for _, value := range field.Values {
+			switch true {
+			case value.String != nil:
+				fmap[field.Key] = *value.String
+			case value.DateTime != nil:
+				fmap[field.Key] = *value.DateTime
+			case value.Date != nil:
+				fmap[field.Key] = *value.Date
+			case value.Time != nil:
+				fmap[field.Key] = *value.Time
+			case value.Bool != nil:
+				fmap[field.Key] = *value.Bool
+			case value.Number != nil:
+				fmap[field.Key] = *value.Number
+			case value.Float != nil:
+				fmap[field.Key] = *value.Float
+			default:
+				return nil, fmt.Errorf("unknown type: %+v", field)
+			}
+		}
+	}
+	return json.Marshal(fmap)
+}
+
+type yamlGrammarPipeline struct {
+	Inputs  []map[string]Fields `yaml:"inputs" json:"inputs"`
+	Filters []map[string]Fields `yaml:"filters,omitempty" json:"filters,omitempty"`
+	Parsers []map[string]Fields `yaml:"parsers,omitempty" json:"parsers,omitempty"`
+	Outputs []map[string]Fields `yaml:"outputs" json:"outputs"`
+	Customs []map[string]Fields `yaml:"customs,omitempty" json:"customs,omitempty"`
+}
+
 type yamlGrammar struct {
-	Service  map[string]interface{} `yaml:"service"`
-	Pipeline yamlGrammarPipeline    `yaml:"pipeline"`
+	Service  map[string]interface{} `yaml:"service" json:"service"`
+	Pipeline yamlGrammarPipeline    `yaml:"pipeline" json:"pipeline"`
 }
 
 func getPluginName(fields map[string]Fields) string {
@@ -597,5 +663,209 @@ func ParseYAML(data []byte) (*Config, error) {
 }
 
 func ParseJSON(data []byte) (*Config, error) {
-	return nil, fmt.Errorf("WIP, unimplemented")
+	var g yamlGrammar
+	err := json.Unmarshal(data, &g)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &Config{
+		PluginIndex: make(map[string]int),
+		Sections:    make([]ConfigSection, 0),
+	}
+
+	if g.Service != nil {
+		service := ConfigSection{
+			Type:   ServiceSection,
+			Fields: make([]Field, 0),
+		}
+		for k, v := range g.Service {
+			value := Value{}
+			switch v.(type) {
+			case string:
+				value.String = stringPtr(v.(string))
+			case int:
+				value.Number = numberPtr(float64(v.(int)))
+			case float64:
+				value.Float = numberPtr(v.(float64))
+			}
+			service.Fields = append(service.Fields, Field{
+				Key:    k,
+				Values: []*Value{&value},
+			})
+		}
+		cfg.Sections = append(cfg.Sections, service)
+	}
+
+	for _, fields := range g.Pipeline.Inputs {
+		pluginName := getPluginName(fields)
+		pluginIndex, ok := cfg.PluginIndex[pluginName]
+		if !ok {
+			pluginIndex = 0
+		}
+		id := fmt.Sprintf("%s.%d", pluginName, pluginIndex)
+		section := ConfigSection{
+			Type:   InputSection,
+			ID:     id,
+			Fields: make([]Field, 0),
+		}
+		for _, fields := range fields {
+			section.Fields = append(section.Fields, fields...)
+		}
+		section.Fields = append(section.Fields, Field{
+			Key:    "name",
+			Values: []*Value{{String: stringPtr(pluginName)}},
+		})
+		cfg.Sections = append(cfg.Sections, section)
+	}
+
+	for _, fields := range g.Pipeline.Filters {
+		pluginName := getPluginName(fields)
+		pluginIndex, ok := cfg.PluginIndex[pluginName]
+		if !ok {
+			pluginIndex = 0
+		}
+		id := fmt.Sprintf("%s.%d", pluginName, pluginIndex)
+		section := ConfigSection{
+			Type:   FilterSection,
+			ID:     id,
+			Fields: make([]Field, 0),
+		}
+		for _, fields := range fields {
+			section.Fields = append(section.Fields, fields...)
+		}
+		section.Fields = append(section.Fields, Field{
+			Key:    "name",
+			Values: []*Value{{String: stringPtr(pluginName)}},
+		})
+		cfg.Sections = append(cfg.Sections, section)
+	}
+	for _, fields := range g.Pipeline.Outputs {
+		pluginName := getPluginName(fields)
+		pluginIndex, ok := cfg.PluginIndex[pluginName]
+		if !ok {
+			pluginIndex = 0
+		}
+		id := fmt.Sprintf("%s.%d", pluginName, pluginIndex)
+		section := ConfigSection{
+			Type:   OutputSection,
+			ID:     id,
+			Fields: make([]Field, 0),
+		}
+		for _, fields := range fields {
+			section.Fields = append(section.Fields, fields...)
+		}
+		section.Fields = append(section.Fields, Field{
+			Key:    "name",
+			Values: []*Value{{String: stringPtr(pluginName)}},
+		})
+		cfg.Sections = append(cfg.Sections, section)
+	}
+
+	for _, fields := range g.Pipeline.Parsers {
+		pluginName := getPluginName(fields)
+		pluginIndex, ok := cfg.PluginIndex[pluginName]
+		if !ok {
+			pluginIndex = 0
+		}
+		id := fmt.Sprintf("%s.%d", pluginName, pluginIndex)
+		section := ConfigSection{
+			Type:   ParserSection,
+			ID:     id,
+			Fields: make([]Field, 0),
+		}
+		for _, fields := range fields {
+			section.Fields = append(section.Fields, fields...)
+		}
+		section.Fields = append(section.Fields, Field{
+			Key:    "name",
+			Values: []*Value{{String: stringPtr(pluginName)}},
+		})
+		cfg.Sections = append(cfg.Sections, section)
+	}
+
+	for _, fields := range g.Pipeline.Customs {
+		pluginName := getPluginName(fields)
+		pluginIndex, ok := cfg.PluginIndex[pluginName]
+		if !ok {
+			pluginIndex = 0
+		}
+		id := fmt.Sprintf("%s.%d", pluginName, pluginIndex)
+		section := ConfigSection{
+			Type:   CustomSection,
+			ID:     id,
+			Fields: make([]Field, 0),
+		}
+		for _, fields := range fields {
+			section.Fields = append(section.Fields, fields...)
+		}
+		section.Fields = append(section.Fields, Field{
+			Key:    "name",
+			Values: []*Value{{String: stringPtr(pluginName)}},
+		})
+		cfg.Sections = append(cfg.Sections, section)
+	}
+
+	return cfg, nil
+}
+
+func DumpJSON(cfg *Config) ([]byte, error) {
+	yg := yamlGrammar{
+		Service: make(map[string]interface{}),
+		Pipeline: yamlGrammarPipeline{
+			Inputs:  make([]map[string]Fields, 0),
+			Filters: make([]map[string]Fields, 0),
+			Outputs: make([]map[string]Fields, 0),
+			Parsers: make([]map[string]Fields, 0),
+			Customs: make([]map[string]Fields, 0),
+		},
+	}
+
+	for _, section := range cfg.Sections {
+		if section.Type == ServiceSection {
+			for _, field := range section.Fields {
+				switch true {
+				case field.Values[0].String != nil:
+					yg.Service[field.Key] = *field.Values[0].String
+				case field.Values[0].DateTime != nil:
+					yg.Service[field.Key] = *field.Values[0].DateTime
+				case field.Values[0].Date != nil:
+					yg.Service[field.Key] = *field.Values[0].Date
+				case field.Values[0].Time != nil:
+					yg.Service[field.Key] = *field.Values[0].Time
+				case field.Values[0].Bool != nil:
+					yg.Service[field.Key] = *field.Values[0].Bool
+				case field.Values[0].Number != nil:
+					yg.Service[field.Key] = *field.Values[0].Number
+				case field.Values[0].Float != nil:
+					yg.Service[field.Key] = *field.Values[0].Float
+				}
+			}
+		} else {
+			sectionName := getPluginNameParameter(section.Fields)
+			sectionmap := make(map[string]Fields)
+			sectionmap[sectionName] = make(Fields, 0)
+
+			for _, field := range section.Fields {
+				sectionmap[sectionName] = append(sectionmap[sectionName], Field{
+					Key:    field.Key,
+					Values: field.Values,
+				})
+			}
+			switch section.Type {
+			case InputSection:
+				yg.Pipeline.Inputs = append(yg.Pipeline.Inputs, sectionmap)
+			case FilterSection:
+				yg.Pipeline.Filters = append(yg.Pipeline.Filters, sectionmap)
+			case OutputSection:
+				yg.Pipeline.Outputs = append(yg.Pipeline.Outputs, sectionmap)
+			case ParserSection:
+				yg.Pipeline.Parsers = append(yg.Pipeline.Parsers, sectionmap)
+			case CustomSection:
+				yg.Pipeline.Customs = append(yg.Pipeline.Customs, sectionmap)
+			}
+		}
+	}
+
+	return json.MarshalIndent(&yg, "", "  ")
 }

--- a/parser.go
+++ b/parser.go
@@ -187,19 +187,19 @@ func (value *Value) dumpValueINI(ini *bytes.Buffer) error {
 	// }
 	switch true {
 	case value.String != nil:
-		ini.Write([]byte(fmt.Sprintf("%s", *value.String)))
+		ini.Write([]byte(*value.String))
 	case value.DateTime != nil:
-		ini.Write([]byte(fmt.Sprintf("%s", *value.DateTime)))
+		ini.Write([]byte(*value.DateTime))
 	case value.Date != nil:
-		ini.Write([]byte(fmt.Sprintf("%s", *value.Date)))
+		ini.Write([]byte(*value.Date))
 	case value.Time != nil:
-		ini.Write([]byte(fmt.Sprintf("%s", *value.Time)))
+		ini.Write([]byte(*value.Time))
 	case value.TimeFormat != nil:
-		ini.Write([]byte(fmt.Sprintf("%s", *value.TimeFormat)))
+		ini.Write([]byte(*value.TimeFormat))
 	case value.Topic != nil:
 		ini.Write([]byte(fmt.Sprintf("$%s", *value.Topic)))
 	case value.Regex != nil:
-		ini.Write([]byte(fmt.Sprintf("%s", *value.Regex)))
+		ini.Write([]byte(*value.Regex))
 	case value.Bool != nil:
 		if *value.Bool {
 			ini.Write([]byte("on"))
@@ -359,44 +359,6 @@ func (fs Fields) MarshalYAML() (interface{}, error) {
 	return fmap, nil
 }
 
-func (fs *Fields) UnmarshalJSON(raw []byte) error {
-	panic("FOO FIGHTORZ")
-	kv := make(map[string]interface{})
-	if err := json.Unmarshal(raw, &kv); err != nil {
-		return err
-	}
-	fields := make([]Field, 0)
-	for k, v := range kv {
-		if k == "name" {
-			continue
-		}
-		switch v.(type) {
-		case string:
-			str := v.(string)
-			fields = append(fields, Field{
-				Key: k,
-				Values: []*Value{{
-					String: &str,
-				}},
-			})
-		case int:
-			i := v.(int)
-			f := float64(i)
-			fields = append(fields, Field{
-				Key: k,
-				Values: []*Value{{
-					Number: &f,
-				}},
-			})
-		default:
-			return fmt.Errorf("unknown type: %+v", v)
-		}
-	}
-	*fs = fields
-
-	return nil
-}
-
 func (fs Fields) MarshalJSON() ([]byte, error) {
 	fmap := make(map[string]interface{})
 	for _, field := range fs {
@@ -439,7 +401,7 @@ type yamlGrammar struct {
 
 func getPluginName(fields map[string]Fields) string {
 	rkey := ""
-	for key, _ := range fields {
+	for key := range fields {
 		rkey = key
 	}
 	return rkey

--- a/parser_test.go
+++ b/parser_test.go
@@ -300,6 +300,320 @@ pipeline:
 	}
 }
 
+func TestParseJSON(t *testing.T) {
+	tt := []struct {
+		name          string
+		config        []byte
+		expected      Config
+		expectedError bool
+	}{
+		{
+			name: "basic configuration",
+			config: []byte(`{
+  "service": {
+    "flush_interval": 1,
+    "log_level": "error"
+  },
+  "pipeline": {
+    "inputs": [
+      {
+        "dummy": {
+          "name": "dummy",
+          "rate": 5
+        }
+      },
+      {
+        "dummy": {
+          "dummy": "{\"FOO\": \"BAR\"}",
+          "name": "dummy",
+          "rate": 1
+        }
+      }
+    ],
+    "filters": [
+      {
+        "record_modifier": {
+          "match": "*",
+          "name": "record_modifier",
+          "record": "powered_by calyptia"
+        }
+      }
+    ],
+    "outputs": [
+      {
+        "stdout": {
+          "match": "*",
+          "name": "stdout"
+        }
+      },
+      {
+        "exit": {
+          "flush_count": 10,
+          "match": "*",
+          "name": "exit"
+        }
+      }
+    ]
+  }
+}`),
+			expected: Config{
+				Sections: []ConfigSection{
+					{
+						Type: ServiceSection,
+						Fields: []Field{
+							{Key: "flush_interval", Values: []*Value{{
+								String:   nil,
+								DateTime: nil,
+								Date:     nil,
+								Time:     nil,
+								Bool:     nil,
+								Number:   numberPtr(1),
+								Float:    nil,
+								List:     nil,
+							}}},
+							{Key: "log_level", Values: []*Value{{
+								String:   stringPtr("error"),
+								DateTime: nil,
+								Date:     nil,
+								Time:     nil,
+								Bool:     nil,
+								Number:   nil,
+								Float:    nil,
+								List:     nil,
+							}}},
+						},
+					},
+					{
+						Type: InputSection,
+						ID:   "dummy.0",
+						Fields: []Field{{
+							Key: "name", Values: []*Value{{
+								String:   stringPtr("dummy"),
+								DateTime: nil,
+								Date:     nil,
+								Time:     nil,
+								Bool:     nil,
+								Number:   nil,
+								Float:    nil,
+								List:     nil,
+							}},
+						},
+							{
+								Key: "rate", Values: []*Value{{
+									String:   nil,
+									DateTime: nil,
+									Date:     nil,
+									Time:     nil,
+									Bool:     nil,
+									Number:   numberPtr(5),
+									Float:    nil,
+									List:     nil,
+								}},
+							},
+						},
+					},
+					{
+						Type: InputSection,
+						ID:   "dummy.1",
+						Fields: []Field{{
+							Key: "name", Values: []*Value{{
+								String:   stringPtr("dummy"),
+								DateTime: nil,
+								Date:     nil,
+								Time:     nil,
+								Bool:     nil,
+								Number:   nil,
+								Float:    nil,
+								List:     nil,
+							}},
+						},
+							{
+								Key: "dummy", Values: []*Value{{
+									String:   stringPtr(`{"FOO": "BAR"}`),
+									DateTime: nil,
+									Date:     nil,
+									Time:     nil,
+									Bool:     nil,
+									Number:   nil,
+									Float:    nil,
+									List:     nil,
+								}},
+							},
+							{
+								Key: "rate", Values: []*Value{{
+									String:   nil,
+									DateTime: nil,
+									Date:     nil,
+									Time:     nil,
+									Bool:     nil,
+									Number:   numberPtr(1),
+									Float:    nil,
+									List:     nil,
+								}},
+							},
+						},
+					},
+					{
+						Type: FilterSection,
+						ID:   "record_modifier.0",
+						Fields: []Field{{
+							Key: "name", Values: []*Value{{
+								String:   stringPtr("record_modifier"),
+								DateTime: nil,
+								Date:     nil,
+								Time:     nil,
+								Bool:     nil,
+								Number:   nil,
+								Float:    nil,
+								List:     nil,
+							}},
+						},
+							{
+								Key: "match", Values: []*Value{{
+									String:   stringPtr("*"),
+									DateTime: nil,
+									Date:     nil,
+									Time:     nil,
+									Bool:     nil,
+									Number:   nil,
+									Float:    nil,
+									List:     nil,
+								}},
+							},
+							{
+								Key: "record", Values: []*Value{{
+									String:   stringPtr("powered_by calyptia"),
+									DateTime: nil,
+									Date:     nil,
+									Time:     nil,
+									Bool:     nil,
+									Number:   nil,
+									Float:    nil,
+									List:     nil,
+								}},
+							},
+						},
+					},
+					{
+						Type: OutputSection,
+						ID:   "stdout.0",
+						Fields: []Field{{
+							Key: "name", Values: []*Value{{
+								String:   stringPtr("stdout"),
+								DateTime: nil,
+								Date:     nil,
+								Time:     nil,
+								Bool:     nil,
+								Number:   nil,
+								Float:    nil,
+								List:     nil,
+							}},
+						},
+							{
+								Key: "match", Values: []*Value{{
+									String:   stringPtr("*"),
+									DateTime: nil,
+									Date:     nil,
+									Time:     nil,
+									Bool:     nil,
+									Number:   nil,
+									Float:    nil,
+									List:     nil,
+								}},
+							},
+						},
+					},
+					{
+						Type: OutputSection,
+						ID:   "exit.1",
+						Fields: []Field{
+							{
+								Key: "name", Values: []*Value{{
+									String:   stringPtr("exit"),
+									DateTime: nil,
+									Date:     nil,
+									Time:     nil,
+									Bool:     nil,
+									Number:   nil,
+									Float:    nil,
+									List:     nil,
+								}},
+							},
+							{
+								Key: "match", Values: []*Value{{
+									String:   stringPtr("*"),
+									DateTime: nil,
+									Date:     nil,
+									Time:     nil,
+									Bool:     nil,
+									Number:   nil,
+									Float:    nil,
+									List:     nil,
+								}},
+							},
+							{
+								Key: "flush_count", Values: []*Value{{
+									String:   nil,
+									DateTime: nil,
+									Date:     nil,
+									Time:     nil,
+									Bool:     nil,
+									Number:   numberPtr(10),
+									Float:    nil,
+									List:     nil,
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := ParseYAML(tc.config)
+			if tc.expectedError && err == nil {
+				t.Errorf("%s expected error", tc.name)
+				return
+			}
+			if tc.expectedError && err != nil {
+				return
+			}
+			if !tc.expectedError && err != nil {
+				t.Error(err)
+				return
+			}
+
+			if want, got := len(tc.expected.Sections), len(cfg.Sections); want != got {
+				fmt.Printf("%+v\n", cfg.Sections)
+				t.Errorf("wants %v != got %v", want, got)
+				return
+			}
+
+			for idx, section := range tc.expected.Sections {
+				if want, got := len(section.Fields), len(cfg.Sections[idx].Fields); want != got {
+					t.Errorf("input[%d] wants %v != got %v", idx, want, got)
+					fmt.Printf("GOT=%+v\n", cfg.Sections[idx].Fields)
+					return
+				}
+			}
+
+			y, err := DumpJSON(cfg)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			if !bytes.Equal(y, tc.config) {
+				fmt.Printf("\n'%s'\n!=\n'%s'\n", string(y), string(tc.config))
+				t.Errorf("json is not reversible")
+				return
+			}
+		})
+	}
+}
+
 func TestNewConfigFromBytes(t *testing.T) {
 	tt := []struct {
 		name          string


### PR DESCRIPTION
I added support for JSON based on the YAML parser. It uses the following format:

```json
{
  "service": {
    "flush_interval": 1,
    "log_level": "error"
  },
  "pipeline": {
    "inputs": [
      {
        "dummy": {
          "name": "dummy",
          "rate": 5
        }
      },
      {
        "dummy": {
          "dummy": "{\"FOO\": \"BAR\"}",
          "name": "dummy",
          "rate": 1
        }
      }
    ],
    "filters": [
      {
        "record_modifier": {
          "match": "*",
          "name": "record_modifier",
          "record": "powered_by calyptia"
        }
      }
    ],
    "outputs": [
      {
        "stdout": {
          "match": "*",
          "name": "stdout"
        }
      },
      {
        "exit": {
          "flush_count": 10,
          "match": "*",
          "name": "exit"
        }
      }
    ]
  }
}
```

Since the code is shared I also generalized the transformation between the shared grammar struct into receiver functions.