### PR TITLE
Fix parsing form TimeFormat

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -16,7 +16,7 @@ var (
 		{"DateTime", `\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d+)?(-\d\d:\d\d)?`, nil},
 		{"Date", `\d\d\d\d-\d\d-\d\d`, nil},
 		{"Time", `\d\d:\d\d:\d\d(\.\d+)?`, nil},
-		{"TimeFormat", `^((%[dbYHMSz])(\:|\/|\ |))+$`, nil},
+		{"TimeFormat", `((%[dbYHMSz])(\:|\/|\ |\-|))+`, nil},
 		{"Ident", `[a-zA-Z_\.\*\-0-9\/\{\}]+`, nil},
 		{"String", `[a-zA-Z0-9_\.\/\*\-]+`, nil},
 		{"Number", `[-+]?[.0-9]+\b`, nil},

--- a/parser.go
+++ b/parser.go
@@ -68,6 +68,87 @@ type Value struct {
 	List       []*Value `| "[" ( @@ ( "," @@ )* )? "]"`
 }
 
+func (a *Value) Equals(b *Value) bool {
+	if a.String != nil {
+		if b.String == nil {
+			return false
+		}
+		return *a.String == *b.String
+	} else if a.DateTime != nil {
+		if b.DateTime == nil {
+			return false
+		}
+		return *a.DateTime == *b.DateTime
+	} else if a.Date != nil {
+		if b.Date == nil {
+			return false
+		}
+		return *a.Date == *b.Date
+	} else if a.Time != nil {
+		if b.Time == nil {
+			return false
+		}
+		return *a.Time == *b.Time
+	} else if a.TimeFormat != nil {
+		if b.TimeFormat == nil {
+			return false
+		}
+		return *a.TimeFormat == *b.TimeFormat
+	} else if a.Topic != nil {
+		if b.Topic == nil {
+			return false
+		}
+		return *a.Topic == *b.Topic
+	} else if a.Regex != nil {
+		if b.Regex == nil {
+			return false
+		}
+		return *a.Regex == *b.Regex
+	} else if a.Bool != nil {
+		if b.Bool == nil {
+			return false
+		}
+		return *a.Bool == *b.Bool
+	} else if a.Number != nil {
+		if b.Number == nil {
+			return false
+		}
+		return *a.Number == *b.Number
+	} else if a.Float != nil {
+		if b.Float == nil {
+			return false
+		}
+		return *a.Float == *b.Float
+	}
+	return false
+}
+
+func (v *Value) Value() interface{} {
+	switch {
+	case v.String != nil:
+		return *v.String
+	case v.DateTime != nil:
+		return *v.DateTime
+	case v.Date != nil:
+		return *v.Date
+	case v.Time != nil:
+		return *v.Time
+	case v.TimeFormat != nil:
+		return *v.TimeFormat
+	case v.Topic != nil:
+		return *v.Topic
+	case v.Regex != nil:
+		return *v.Regex
+	case v.Bool != nil:
+		return *v.Bool
+	case v.Number != nil:
+		return *v.Number
+	case v.Float != nil:
+		return *v.Float
+	}
+	return nil
+}
+
 type ConfigSectionType int
 
 const (

--- a/parser_test.go
+++ b/parser_test.go
@@ -648,7 +648,8 @@ func TestNewConfigFromBytes(t *testing.T) {
 					Format regex
 					Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>.*)")?$
 					Time_Key time
-					Time_Format %d/%b/%Y:%H:%M:%S %z`),
+					Time_Format %d/%b/%Y:%H:%M:%S %z
+			`),
 			expected: Config{
 				Sections: []ConfigSection{{
 					Type: InputSection,

--- a/parser_test.go
+++ b/parser_test.go
@@ -1107,6 +1107,45 @@ func TestNewConfigFromBytes(t *testing.T) {
 			},
 			expectedError: false,
 		},
+		{
+			name: "test valid larger configuration",
+			config: []byte(`
+[PARSER]
+	Name        syslog-rfc3164-local
+	Format      regex
+	Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+	Time_Key    time
+	Time_Format %b %d %H:%M:%S
+	Time_Keep   On
+			`),
+			// %b %d %H:%M:%S
+			expected: Config{
+				Sections: []ConfigSection{{
+					Type: ParserSection,
+					Fields: []Field{
+						{Key: "Name", Values: []*Value{{
+							String:   stringPtr("syslog-rfc3164-local"),
+						}}},
+						{Key: "Format", Values: []*Value{{
+							String:   stringPtr("regex"),
+						}}},
+						{Key: "Regex", Values: []*Value{{
+							String:   stringPtr(`^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$`),
+						}}},
+						{Key: "Time_Key", Values: []*Value{{
+							String:   stringPtr("time"),
+						}}},
+						{Key: "Time_Format", Values: []*Value{{
+							String:   stringPtr("%b %d %H:%M:%S"),
+						}}},
+						{Key: "Time_Keep", Values: []*Value{{
+							String:   stringPtr("On"),
+						}}},
+					},
+				}},
+			},
+			expectedError: false,
+		},
 	}
 
 	stripIndentation := regexp.MustCompile("\n[\t]+")

--- a/parser_test.go
+++ b/parser_test.go
@@ -655,34 +655,13 @@ func TestNewConfigFromBytes(t *testing.T) {
 					Type: InputSection,
 					Fields: []Field{
 						{Key: "name", Values: []*Value{{
-							String:   stringPtr("tail"),
-							DateTime: nil,
-							Date:     nil,
-							Time:     nil,
-							Bool:     nil,
-							Number:   nil,
-							Float:    nil,
-							List:     nil,
+							String: stringPtr("tail"),
 						}}},
 						{Key: "tag", Values: []*Value{{
-							String:   stringPtr("kube.*"),
-							DateTime: nil,
-							Date:     nil,
-							Time:     nil,
-							Bool:     nil,
-							Number:   nil,
-							Float:    nil,
-							List:     nil,
+							String: stringPtr("kube.*"),
 						}}},
 						{Key: "mem_buf_limit", Values: []*Value{{
-							String:   stringPtr("4.8M"),
-							DateTime: nil,
-							Date:     nil,
-							Time:     nil,
-							Bool:     nil,
-							Number:   nil,
-							Float:    nil,
-							List:     nil,
+							String: stringPtr("4.8M"),
 						}}},
 					},
 				}, {
@@ -691,62 +670,27 @@ func TestNewConfigFromBytes(t *testing.T) {
 						{
 							Key: "Name",
 							Values: []*Value{{
-								String:   stringPtr("apache2"),
-								DateTime: nil,
-								Date:     nil,
-								Time:     nil,
-								Bool:     nil,
-								Number:   nil,
-								Float:    nil,
-								List:     nil,
+								String: stringPtr("apache2"),
 							}},
 						},
 						{
 							Key: "Format", Values: []*Value{{
-								String:   stringPtr("regex"),
-								DateTime: nil,
-								Date:     nil,
-								Time:     nil,
-								Bool:     nil,
-								Number:   nil,
-								Float:    nil,
-								List:     nil,
+								String: stringPtr("regex"),
 							}},
 						},
 						{
 							Key: "Regex", Values: []*Value{{
-								String:   stringPtr(`^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>.*)")?$`),
-								DateTime: nil,
-								Date:     nil,
-								Time:     nil,
-								Bool:     nil,
-								Number:   nil,
-								Float:    nil,
-								List:     nil,
+								Regex: stringPtr(`^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>.*)")?$`),
 							}},
 						},
 						{
 							Key: "Time_Key", Values: []*Value{{
-								String:   stringPtr("time"),
-								DateTime: nil,
-								Date:     nil,
-								Time:     nil,
-								Bool:     nil,
-								Number:   nil,
-								Float:    nil,
-								List:     nil,
+								String: stringPtr("time"),
 							}},
 						},
 						{
 							Key: "Time_Format", Values: []*Value{{
-								String:   stringPtr("%d/%b/%Y:%H:%M:%S %z"),
-								DateTime: nil,
-								Date:     nil,
-								Time:     nil,
-								Bool:     nil,
-								Number:   nil,
-								Float:    nil,
-								List:     nil,
+								TimeFormat: stringPtr("%d/%b/%Y:%H:%M:%S %z"),
 							}},
 						},
 					},
@@ -822,9 +766,9 @@ func TestNewConfigFromBytes(t *testing.T) {
 						tag kube.*
 						mem_buf_limit 4.8M
 					[FILTER]
-						name rewrite_tag
+						Name rewrite_tag
+						Match mqtt
 						Rule topic tele sonoff true
-						match mqtt
 			`),
 			// Rule  $topic ^tele\/[^\/]+\/SENSOR$ sonoff true
 			expected: Config{
@@ -832,34 +776,13 @@ func TestNewConfigFromBytes(t *testing.T) {
 					Type: InputSection,
 					Fields: []Field{
 						{Key: "name", Values: []*Value{{
-							String:   stringPtr("tail"),
-							DateTime: nil,
-							Date:     nil,
-							Time:     nil,
-							Bool:     nil,
-							Number:   nil,
-							Float:    nil,
-							List:     nil,
+							String: stringPtr("tail"),
 						}}},
 						{Key: "tag", Values: []*Value{{
-							String:   stringPtr("kube.*"),
-							DateTime: nil,
-							Date:     nil,
-							Time:     nil,
-							Bool:     nil,
-							Number:   nil,
-							Float:    nil,
-							List:     nil,
+							String: stringPtr("kube.*"),
 						}}},
 						{Key: "mem_buf_limit", Values: []*Value{{
-							String:   stringPtr("4.8M"),
-							DateTime: nil,
-							Date:     nil,
-							Time:     nil,
-							Bool:     nil,
-							Number:   nil,
-							Float:    nil,
-							List:     nil,
+							String: stringPtr("4.8M"),
 						}}},
 					},
 				}, {
@@ -868,40 +791,20 @@ func TestNewConfigFromBytes(t *testing.T) {
 						{
 							Key: "Name",
 							Values: []*Value{{
-								String:   stringPtr("rewrite_tag"),
-								DateTime: nil,
-								Date:     nil,
-								Time:     nil,
-								Bool:     nil,
-								Number:   nil,
-								Float:    nil,
-								List:     nil,
+								String: stringPtr("rewrite_tag"),
 							}},
 						},
 						{
 							Key: "Match", Values: []*Value{{
-								String:   stringPtr("mqtt"),
-								DateTime: nil,
-								Date:     nil,
-								Time:     nil,
-								Bool:     nil,
-								Number:   nil,
-								Float:    nil,
-								List:     nil,
+								String: stringPtr("mqtt"),
 							}},
 						},
 						{
 							Key: "Rule", Values: []*Value{
-								{
-									String:   stringPtr("mqtt"),
-									DateTime: nil,
-									Date:     nil,
-									Time:     nil,
-									Bool:     nil,
-									Number:   nil,
-									Float:    nil,
-									List:     nil,
-								},
+								{String: stringPtr("topic")},
+								{String: stringPtr("tele")},
+								{String: stringPtr("sonoff")},
+								{String: stringPtr("true")},
 							},
 						},
 					},
@@ -926,68 +829,26 @@ func TestNewConfigFromBytes(t *testing.T) {
 					Type: InputSection,
 					Fields: []Field{
 						{Key: "name", Values: []*Value{{
-							String:   stringPtr("tail"),
-							DateTime: nil,
-							Date:     nil,
-							Time:     nil,
-							Bool:     nil,
-							Number:   nil,
-							Float:    nil,
-							List:     nil,
+							String: stringPtr("tail"),
 						}}},
 						{Key: "tag", Values: []*Value{{
-							String:   stringPtr("tail.01"),
-							DateTime: nil,
-							Date:     nil,
-							Time:     nil,
-							Bool:     nil,
-							Number:   nil,
-							Float:    nil,
-							List:     nil,
+							String: stringPtr("tail.01"),
 						}}},
 						{Key: "Path", Values: []*Value{{
-							String:   stringPtr("/var/log/system.log"),
-							DateTime: nil,
-							Date:     nil,
-							Time:     nil,
-							Bool:     nil,
-							Number:   nil,
-							Float:    nil,
-							List:     nil,
+							String: stringPtr("/var/log/system.log"),
 						}}},
 					},
 				}, {
 					Type: OutputSection,
 					Fields: []Field{
 						{Key: "name", Values: []*Value{{
-							String:   stringPtr("s3"),
-							DateTime: nil,
-							Date:     nil,
-							Time:     nil,
-							Bool:     nil,
-							Number:   nil,
-							Float:    nil,
-							List:     nil,
+							String: stringPtr("s3"),
 						}}},
 						{Key: "Match", Values: []*Value{{
-							String:   stringPtr("*"),
-							DateTime: nil,
-							Date:     nil,
-							Time:     nil,
-							Bool:     nil,
-							Number:   nil,
-							Float:    nil,
-							List:     nil,
+							String: stringPtr("*"),
 						}}},
 						{Key: "bucket", Values: []*Value{{
-							String:   stringPtr("your-bucket"),
-							DateTime: nil,
-							Date:     nil,
-							Time:     nil,
-							Bool:     nil,
-							Number:   nil,
-							Float:    nil,
-							List:     nil,
+							String: stringPtr("your-bucket"),
 						}}},
 					},
 				}},
@@ -995,7 +856,7 @@ func TestNewConfigFromBytes(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "test valid larger configuration",
+			name: "test valid multiple inputs",
 			config: []byte(`
 				[INPUT]
 					Name tcp
@@ -1016,92 +877,37 @@ func TestNewConfigFromBytes(t *testing.T) {
 					Type: InputSection,
 					Fields: []Field{
 						{Key: "Name", Values: []*Value{{
-							String:   stringPtr("tcp"),
-							DateTime: nil,
-							Date:     nil,
-							Time:     nil,
-							Bool:     nil,
-							Number:   nil,
-							Float:    nil,
-							List:     nil,
+							String: stringPtr("tcp"),
 						}}},
 						{Key: "Port", Values: []*Value{{
-							String:   nil,
-							DateTime: nil,
-							Date:     nil,
-							Time:     nil,
-							Bool:     nil,
-							Number:   numberPtr(5556),
-							Float:    nil,
-							List:     nil,
+							String: stringPtr("5556"),
+							List:   nil,
 						}}},
 						{Key: "Tag", Values: []*Value{{
-							String:   stringPtr("foobar"),
-							DateTime: nil,
-							Date:     nil,
-							Time:     nil,
-							Bool:     nil,
-							Number:   nil,
-							Float:    nil,
-							List:     nil,
+							String: stringPtr("foobar"),
 						}}},
 					},
 				}, {
 					Type: InputSection,
 					Fields: []Field{
 						{Key: "Name", Values: []*Value{{
-							String:   stringPtr("tcp"),
-							DateTime: nil,
-							Date:     nil,
-							Time:     nil,
-							Bool:     nil,
-							Number:   nil,
-							Float:    nil,
-							List:     nil,
+							String: stringPtr("tcp"),
 						}}},
 						{Key: "Port", Values: []*Value{{
-							String:   nil,
-							DateTime: nil,
-							Date:     nil,
-							Time:     nil,
-							Bool:     nil,
-							Number:   numberPtr(5557),
-							Float:    nil,
-							List:     nil,
+							String: stringPtr("5557"),
 						}}},
 						{Key: "Tag", Values: []*Value{{
-							String:   stringPtr("foobat"),
-							DateTime: nil,
-							Date:     nil,
-							Time:     nil,
-							Bool:     nil,
-							Number:   nil,
-							Float:    nil,
-							List:     nil,
+							String: stringPtr("foobat"),
 						}}},
 					},
 				}, {
 					Type: OutputSection,
 					Fields: []Field{
 						{Key: "name", Values: []*Value{{
-							String:   stringPtr("stdout"),
-							DateTime: nil,
-							Date:     nil,
-							Time:     nil,
-							Bool:     nil,
-							Number:   nil,
-							Float:    nil,
-							List:     nil,
+							String: stringPtr("stdout"),
 						}}},
 						{Key: "Match", Values: []*Value{{
-							String:   stringPtr("*"),
-							DateTime: nil,
-							Date:     nil,
-							Time:     nil,
-							Bool:     nil,
-							Number:   nil,
-							Float:    nil,
-							List:     nil,
+							String: stringPtr("*"),
 						}}},
 					},
 				}},
@@ -1109,38 +915,37 @@ func TestNewConfigFromBytes(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "test valid larger configuration",
+			name: "test time formats",
 			config: []byte(`
-[PARSER]
-	Name        syslog-rfc3164-local
-	Format      regex
-	Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
-	Time_Key    time
-	Time_Format %b %d %H:%M:%S
-	Time_Keep   On
+				[PARSER]
+					Name        syslog-rfc3164-local
+					Format      regex
+					Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+					Time_Key    time
+					Time_Format %b %d %H:%M:%S
+					Time_Keep   On
 			`),
-			// %b %d %H:%M:%S
 			expected: Config{
 				Sections: []ConfigSection{{
 					Type: ParserSection,
 					Fields: []Field{
 						{Key: "Name", Values: []*Value{{
-							String:   stringPtr("syslog-rfc3164-local"),
+							String: stringPtr("syslog-rfc3164-local"),
 						}}},
 						{Key: "Format", Values: []*Value{{
-							String:   stringPtr("regex"),
+							String: stringPtr("regex"),
 						}}},
 						{Key: "Regex", Values: []*Value{{
-							String:   stringPtr(`^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$`),
+							Regex: stringPtr(`^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$`),
 						}}},
 						{Key: "Time_Key", Values: []*Value{{
-							String:   stringPtr("time"),
+							String: stringPtr("time"),
 						}}},
 						{Key: "Time_Format", Values: []*Value{{
-							String:   stringPtr("%b %d %H:%M:%S"),
+							TimeFormat: stringPtr("%b %d %H:%M:%S"),
 						}}},
 						{Key: "Time_Keep", Values: []*Value{{
-							String:   stringPtr("On"),
+							String: stringPtr("On"),
 						}}},
 					},
 				}},
@@ -1174,9 +979,21 @@ func TestNewConfigFromBytes(t *testing.T) {
 
 			for idx, section := range tc.expected.Sections {
 				if want, got := len(section.Fields), len(cfg.Sections[idx].Fields); want != got {
-					t.Errorf("input[%d] wants %v != got %v", idx, want, got)
-					fmt.Printf("GOT=%+v\n", cfg.Sections[idx].Fields)
+					t.Errorf("section[%d] wants %v != got %v", idx, want, got)
 					return
+				}
+
+				for fidx, field := range section.Fields {
+					if want, got := len(field.Values), len(cfg.Sections[idx].Fields[fidx].Values); want != got {
+						t.Errorf("section[%d].fields[%s:%d] %d != got %d", idx, field.Key, fidx, want, got)
+						return
+					}
+					for vidx, value := range cfg.Sections[idx].Fields[fidx].Values {
+						if !value.Equals(field.Values[vidx]) {
+							t.Errorf("unexpected value section[%d].fields[%s]", idx, field.Key)
+							return
+						}
+					}
 				}
 			}
 


### PR DESCRIPTION
The old lexer definition would not pass TimeFormat if they were defined anywhere besides the strict end of the byte stream, ie: even a newline at the end would cause it to not parse correctly.

Here not only did I fix it but I added code to test the expected values and fixed expected values which were incorrectly defined.

There still is one last problem: Number never gets used due to the lexer order. I attempted to fix it naively by just bumping it up but was unable to luck out on the correct order. I just defined some expected number values as strings for now.
