### PR TITLE
parser: add missing format specifiers from strptime.

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -16,7 +16,7 @@ var (
 		{"DateTime", `\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d+)?(-\d\d:\d\d)?`, nil},
 		{"Date", `\d\d\d\d-\d\d-\d\d`, nil},
 		{"Time", `\d\d:\d\d:\d\d(\.\d+)?`, nil},
-		{"TimeFormat", `((%[dbYHMSz])(\:|\/|\ |\-|))+`, nil},
+		{"TimeFormat", `((%([aAbBhcCdeDHIjmMnprRStTUwWxXyYLz]|E[cCxXyY]|O[deHImMSUwWy]))(\:|\/| |\-|T|Z|\.|))+`, nil},
 		{"Ident", `[a-zA-Z_\.\*\-0-9\/\{\}]+`, nil},
 		{"String", `[a-zA-Z0-9_\.\/\*\-]+`, nil},
 		{"Number", `[-+]?[.0-9]+\b`, nil},

--- a/parser_test.go
+++ b/parser_test.go
@@ -924,6 +924,13 @@ func TestNewConfigFromBytes(t *testing.T) {
 					Time_Key    time
 					Time_Format %b %d %H:%M:%S
 					Time_Keep   On
+				[PARSER]
+					Name        mongodb
+					Format      regex
+					Regex       ^(?<time>[^ ]*)\s+(?<severity>\w)\s+(?<component>[^ ]+)\s+\[(?<context>[^\]]+)]\s+(?<message>.*?) *(?<ms>(\d+))?(:?ms)?$
+					Time_Format %Y-%m-%dT%H:%M:%S.%L
+					Time_Keep   On
+					Time_Key    time
 			`),
 			expected: Config{
 				Sections: []ConfigSection{{
@@ -946,6 +953,28 @@ func TestNewConfigFromBytes(t *testing.T) {
 						}}},
 						{Key: "Time_Keep", Values: []*Value{{
 							String: stringPtr("On"),
+						}}},
+					},
+				}, {
+					Type: ParserSection,
+					Fields: []Field{
+						{Key: "Name", Values: []*Value{{
+							String: stringPtr("mongodb"),
+						}}},
+						{Key: "Format", Values: []*Value{{
+							String: stringPtr("regex"),
+						}}},
+						{Key: "Regex", Values: []*Value{{
+							Regex: stringPtr(`^(?<time>[^ ]*)\s+(?<severity>\w)\s+(?<component>[^ ]+)\s+\[(?<context>[^\]]+)]\s+(?<message>.*?) *(?<ms>(\d+))?(:?ms)?$`),
+						}}},
+						{Key: "Time_Format", Values: []*Value{{
+							TimeFormat: stringPtr("%Y-%m-%dT%H:%M:%S.%L"),
+						}}},
+						{Key: "Time_Keep", Values: []*Value{{
+							String: stringPtr("On"),
+						}}},
+						{Key: "Time_Key", Values: []*Value{{
+							String: stringPtr("time"),
 						}}},
 					},
 				}},


### PR DESCRIPTION
Add all the missing formats that strptime supports, including %E* a %O* format specifiers. 

Also added the %L specifier that mongodb uses but is not documented as supported by strptime:  https://linux.die.net/man/3/strptime.

This might actually be an unsupported format specifier.