### PR TITLE
fix valid size

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -409,6 +409,12 @@ func validByteSize(prop Field) bool {
 		return true
 	}
 
+	// try with number as string
+	if len(prop.Values) == 1 && prop.Values[0].String != nil {
+		_, err := strconv.ParseInt(*prop.Values[0].String, 10, 64)
+		return err == nil
+	}
+
 	// try with bytes parser.
 	_, err := bytefmt.ToBytes(prop.Values.ToString())
 	if err == nil {

--- a/validator_test.go
+++ b/validator_test.go
@@ -359,6 +359,14 @@ func TestConfigSection_Validate(t *testing.T) {
 			kind: NoneSection,
 			want: `unsupported plugin kind "NONE"`,
 		},
+		{
+			name: "input_forward_buffer_max_size_size",
+			kind: InputSection,
+			props: map[string]string{
+				"Name":            "forward",
+				"buffer_max_size": "61440000",
+			},
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Quick fix for actually valid size.
Size as string was not validated to check if its string value is a number.

Closes https://github.com/calyptia/go-fluentbit-config/issues/32