### PR TITLE
Add DumpAs helper method to config.

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -1020,7 +1020,7 @@ func TestINItoJSON(t *testing.T) {
 				return
 			}
 
-			jsonconfig, err := DumpJSON(cfg)
+			jsonconfig, err := cfg.DumpAs(ConfigFormatJSON)
 			if err != nil {
 				t.Error(err)
 				return
@@ -1091,7 +1091,7 @@ func TestJSONtoINI(t *testing.T) {
 				return
 			}
 
-			ini, err := cfg.DumpINI()
+			ini, err := cfg.DumpAs(ConfigFormatINI)
 			if err != nil {
 				t.Error(err)
 				return

--- a/validator.go
+++ b/validator.go
@@ -164,8 +164,8 @@ type SchemaOptions struct {
 }
 
 // Validate with the default schema.
-func (cfg *Config) Validate() error {
-	return cfg.ValidateWithSchema(DefaultSchema)
+func (c *Config) Validate() error {
+	return c.ValidateWithSchema(DefaultSchema)
 }
 
 // ValidateWithSchema validates that the config satisfies
@@ -173,8 +173,8 @@ func (cfg *Config) Validate() error {
 // That is if the schema says the the input plugin "cpu"
 // has a property named "pid" that is of integer type,
 // it must be a valid integer.
-func (cfg *Config) ValidateWithSchema(schema Schema) error {
-	for _, section := range cfg.Sections {
+func (c *Config) ValidateWithSchema(schema Schema) error {
+	for _, section := range c.Sections {
 		if !supportedSchemaSection(section.Type) {
 			// TODO: support all sections on schema.
 			continue


### PR DESCRIPTION
- To avoid duplicate the format/switch logic over different places lets add a dumpAs method to the configuration
type.

Signed-off-by: Jorge Niedbalski <j@calyptia.com>