### PR TITLE
Fix json object output for INI.

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -418,6 +418,8 @@ func (a *Value) dumpValueINI(ini *bytes.Buffer) error {
 		ini.Write([]byte(fmt.Sprintf("%0.6f", *a.Float)))
 	case a.JsonObject != nil:
 		ini.Write([]byte(*a.JsonObject))
+	case a.Address != nil:
+		ini.Write([]byte(*a.Address))
 	case a.List != nil:
 		//for _, v := range value.List {
 		//if err := v.dumpValueINI(ini); err != nil {

--- a/parser.go
+++ b/parser.go
@@ -416,6 +416,8 @@ func (a *Value) dumpValueINI(ini *bytes.Buffer) error {
 		ini.Write([]byte(fmt.Sprintf("%d", int(*a.Number))))
 	case a.Float != nil:
 		ini.Write([]byte(fmt.Sprintf("%0.6f", *a.Float)))
+	case a.JsonObject != nil:
+		ini.Write([]byte(*a.JsonObject))
 	case a.List != nil:
 		//for _, v := range value.List {
 		//if err := v.dumpValueINI(ini); err != nil {

--- a/tests/ini-to-json/17-json-object.ini
+++ b/tests/ini-to-json/17-json-object.ini
@@ -1,0 +1,15 @@
+[INPUT]
+    dummy {"message":"dummy"}
+    rate 1
+    samples 0
+    start_time_sec -1
+    start_time_nsec -1
+    Name dummy
+    tag dummy.2a227ce1-6a50-4ad2-ba37-9e436c454116
+[OUTPUT]
+    host calyptia-vivo
+    port 5489
+    uri /console
+    format json
+    Name http
+    Match *

--- a/tests/ini-to-json/17-json-object.json
+++ b/tests/ini-to-json/17-json-object.json
@@ -1,0 +1,29 @@
+{
+  "pipeline":{
+    "inputs":[
+      {
+        "dummy":{
+          "dummy":"{\"message\":\"dummy\"}",
+          "rate":1,
+          "samples":0,
+          "start_time_sec":-1,
+          "start_time_nsec":-1,
+          "Name":"dummy",
+          "tag":"dummy.2a227ce1-6a50-4ad2-ba37-9e436c454116"
+        }
+      }
+    ],
+    "outputs":[
+      {
+        "http":{
+          "host":"calyptia-vivo",
+          "port":5489,
+          "uri":"/console",
+          "format":"json",
+          "Name":"http",
+          "Match":"*"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
When dumping INI format, json objects were ignored, causing for the value of the entry to be discarded.

This patch fixes that and adds a test to ensure parsing back and forth works correctly.

This is patch 1/2 to fix the issue related to https://github.com/calyptia/cloud/issues/632 reported by @eduardo

Signed-off-by: Jorge Niedbalski <j@calyptia.com>