### PR TITLE
v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: "1.20"
       - name: Test
         run: go test -race -v ./...
 
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: "1.20"
 
       - uses: goreleaser/goreleaser-action@v2
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [main]
 jobs:
-  test:
+  go:
     runs-on: ubuntu-latest
     steps:
       # Checkout your project with git

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,28 +10,31 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: "1.20"
-      - name: Test
-        run: go test -race -v ./...
+      # Checkout your project with git
+      - name: Checkout
+        uses: actions/checkout@v3
 
-  goreleaser:
-    name: goreleaser
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+      # Install Go on the VM running the action.
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "^1.20"
 
-      - uses: goreleaser/goreleaser-action@v2
-        if: startsWith(github.ref, 'refs/tags/v')
+      # Install gotestfmt on the VM running the action.
+      - name: Set up gotestfmt
+        run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+
+      # Run tests with nice formatting. Save the original log in /tmp/gotest.log
+      - name: Run tests
+        run: |
+          set -euo pipefail
+          go test -json -race -v ./... 2>&1 | tee /tmp/gotest.log | gotestfmt -hide all
+
+      # Upload the original go test log as an artifact for later review.
+      - name: Upload test log
+        uses: actions/upload-artifact@v3
+        if: always()
         with:
-          version: latest
-          args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: test-log
+          path: /tmp/gotest.log
+          if-no-files-found: error

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
 
       # Install gotestfmt on the VM running the action.
       - name: Set up gotestfmt
-        run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+        run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@v2
 
       # Run tests with nice formatting. Save the original log in /tmp/gotest.log
       - name: Run tests

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,2 +1,0 @@
-builds:
-  - skip: true

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # go-fluentbit-config
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/calyptia/go-fluentbit-config.svg)](https://pkg.go.dev/github.com/calyptia/go-fluentbit-config)
+[![Go Reference](https://pkg.go.dev/badge/github.com/calyptia/go-fluentbit-config/v2.svg)](https://pkg.go.dev/github.com/calyptia/go-fluentbit-config/v2)
 
 Library to parse Fluent Bit config files. With support for both the classic/legacy mode (INI), and the new YAML config.
 
 ```bash
-go get github.com/calyptia/go-fluentbit-config
+go get github.com/calyptia/go-fluentbit-config/v2
 ```

--- a/config.go
+++ b/config.go
@@ -4,28 +4,25 @@ import (
 	"fmt"
 	"strings"
 
-	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 
-	"github.com/calyptia/go-fluentbit-config/property"
+	"github.com/calyptia/go-fluentbit-config/v2/property"
 )
 
 type Config struct {
 	Env      property.Properties `json:"env,omitempty" yaml:"env,omitempty"`
 	Includes []string            `json:"includes,omitempty" yaml:"includes,omitempty"`
 	Service  property.Properties `json:"service,omitempty" yaml:"service,omitempty"`
-	Customs  []ByName            `json:"customs,omitempty" yaml:"customs,omitempty"`
+	Customs  Plugins             `json:"customs,omitempty" yaml:"customs,omitempty"`
 	Pipeline Pipeline            `json:"pipeline,omitempty" yaml:"pipeline,omitempty"`
 }
 
 type Pipeline struct {
-	Inputs  []ByName `json:"inputs,omitempty" yaml:"inputs,omitempty"`
-	Parsers []ByName `json:"parsers,omitempty" yaml:"parsers,omitempty"`
-	Filters []ByName `json:"filters,omitempty" yaml:"filters,omitempty"`
-	Outputs []ByName `json:"outputs,omitempty" yaml:"outputs,omitempty"`
+	Inputs  Plugins `json:"inputs,omitempty" yaml:"inputs,omitempty"`
+	Parsers Plugins `json:"parsers,omitempty" yaml:"parsers,omitempty"`
+	Filters Plugins `json:"filters,omitempty" yaml:"filters,omitempty"`
+	Outputs Plugins `json:"outputs,omitempty" yaml:"outputs,omitempty"`
 }
-
-type ByName map[string]property.Properties
 
 func (c *Config) SetEnv(key string, value any) {
 	if c.Env == nil {
@@ -54,21 +51,25 @@ func (c *Config) AddSection(kind SectionKind, props property.Properties) {
 		return
 	}
 
-	byName := ByName{
-		name: props,
+	makePlugin := func(i int) Plugin {
+		return Plugin{
+			ID:         fmt.Sprintf("%s.%d", name, i),
+			Name:       name,
+			Properties: props,
+		}
 	}
 
 	switch kind {
 	case SectionKindCustom:
-		c.Customs = append(c.Customs, byName)
+		c.Customs = append(c.Customs, makePlugin(len(c.Customs)))
 	case SectionKindInput:
-		c.Pipeline.Inputs = append(c.Pipeline.Inputs, byName)
+		c.Pipeline.Inputs = append(c.Pipeline.Inputs, makePlugin(len(c.Pipeline.Inputs)))
 	case SectionKindParser:
-		c.Pipeline.Parsers = append(c.Pipeline.Parsers, byName)
+		c.Pipeline.Parsers = append(c.Pipeline.Parsers, makePlugin(len(c.Pipeline.Parsers)))
 	case SectionKindFilter:
-		c.Pipeline.Filters = append(c.Pipeline.Filters, byName)
+		c.Pipeline.Filters = append(c.Pipeline.Filters, makePlugin(len(c.Pipeline.Filters)))
 	case SectionKindOutput:
-		c.Pipeline.Outputs = append(c.Pipeline.Outputs, byName)
+		c.Pipeline.Outputs = append(c.Pipeline.Outputs, makePlugin(len(c.Pipeline.Outputs)))
 	}
 }
 
@@ -85,55 +86,27 @@ func (c Config) Equal(target Config) bool {
 		return false
 	}
 
-	if !equalByNames(c.Customs, target.Customs) {
+	if !c.Customs.Equal(target.Customs) {
 		return false
 	}
 
-	if !equalByNames(c.Pipeline.Inputs, target.Pipeline.Inputs) {
+	if !c.Pipeline.Inputs.Equal(target.Pipeline.Inputs) {
 		return false
 	}
 
-	if !equalByNames(c.Pipeline.Parsers, target.Pipeline.Parsers) {
+	if !c.Pipeline.Parsers.Equal(target.Pipeline.Parsers) {
 		return false
 	}
 
-	if !equalByNames(c.Pipeline.Filters, target.Pipeline.Filters) {
+	if !c.Pipeline.Filters.Equal(target.Pipeline.Filters) {
 		return false
 	}
 
-	if !equalByNames(c.Pipeline.Outputs, target.Pipeline.Outputs) {
+	if !c.Pipeline.Outputs.Equal(target.Pipeline.Outputs) {
 		return false
 	}
 
 	return true
-}
-
-func (c Config) IDs(withPrefix bool) []string {
-	collect := func(kind SectionKind, byNames []ByName) []string {
-		var ids []string
-		for i, byName := range byNames {
-			for name, props := range byName {
-				if s := Name(props); s != "" {
-					name = s
-				}
-				if withPrefix {
-					ids = append(ids, fmt.Sprintf("%s:%s:%s.%d", kind, name, name, i))
-				} else {
-					ids = append(ids, fmt.Sprintf("%s.%d", name, i))
-				}
-				break
-			}
-		}
-		return ids
-	}
-
-	var ids []string
-	ids = append(ids, collect(SectionKindCustom, c.Customs)...)
-	ids = append(ids, collect(SectionKindInput, c.Pipeline.Inputs)...)
-	ids = append(ids, collect(SectionKindParser, c.Pipeline.Parsers)...)
-	ids = append(ids, collect(SectionKindFilter, c.Pipeline.Filters)...)
-	ids = append(ids, collect(SectionKindOutput, c.Pipeline.Outputs)...)
-	return ids
 }
 
 // Name from properties.
@@ -143,19 +116,6 @@ func Name(props property.Properties) string {
 		return ""
 	}
 
-	if name, ok := nameVal.(string); ok {
-		return strings.TrimSpace(strings.ToValidUTF8(name, ""))
-	}
-
-	return strings.TrimSpace(strings.ToValidUTF8(fmt.Sprintf("%v", nameVal), ""))
-}
-
-func equalByNames(a, b []ByName) bool {
-	return slices.EqualFunc(a, b, equalByName)
-}
-
-func equalByName(a, b ByName) bool {
-	return maps.EqualFunc(a, b, func(v1, v2 property.Properties) bool {
-		return v1.Equal(v2)
-	})
+	name := stringFromAny(nameVal)
+	return strings.ToLower(strings.TrimSpace(strings.ToValidUTF8(name, "")))
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,4 +1,4 @@
-package fluentbitconfig_test
+package fluentbitconfig
 
 import (
 	"bytes"
@@ -11,8 +11,7 @@ import (
 	"github.com/alecthomas/assert/v2"
 	"gopkg.in/yaml.v3"
 
-	fluentbitconfig "github.com/calyptia/go-fluentbit-config"
-	"github.com/calyptia/go-fluentbit-config/property"
+	"github.com/calyptia/go-fluentbit-config/v2/property"
 )
 
 func Test_Config(t *testing.T) {
@@ -24,21 +23,21 @@ func Test_Config(t *testing.T) {
 			classicText, err := os.ReadFile(name)
 			assert.NoError(t, err)
 
-			var classicConf fluentbitconfig.Config
+			var classicConf Config
 			err = classicConf.UnmarshalClassic(classicText)
 			assert.NoError(t, err)
 
 			yamlText, err := os.ReadFile(strings.Replace(name, ".conf", ".yaml", 1))
 			assert.NoError(t, err)
 
-			var yamlConf fluentbitconfig.Config
+			var yamlConf Config
 			err = yaml.Unmarshal(yamlText, &yamlConf)
 			assert.NoError(t, err)
 
 			jsonText, err := os.ReadFile(strings.Replace(name, ".conf", ".json", 1))
 			assert.NoError(t, err)
 
-			var jsonConf fluentbitconfig.Config
+			var jsonConf Config
 			err = json.Unmarshal(jsonText, &jsonConf)
 			assert.NoError(t, err)
 
@@ -73,12 +72,12 @@ func makeTestName(fp string) string {
 
 func TestConfig_Equal(t *testing.T) {
 	t.Run("equal_env", func(t *testing.T) {
-		a := fluentbitconfig.Config{
+		a := Config{
 			Env: property.Properties{
 				{Key: "foo", Value: "bar"},
 			},
 		}
-		b := fluentbitconfig.Config{
+		b := Config{
 			Env: property.Properties{
 				{Key: "foo", Value: "bar"},
 			},
@@ -87,12 +86,12 @@ func TestConfig_Equal(t *testing.T) {
 	})
 
 	t.Run("not_equal_env", func(t *testing.T) {
-		a := fluentbitconfig.Config{
+		a := Config{
 			Env: property.Properties{
 				{Key: "a", Value: "b"},
 			},
 		}
-		b := fluentbitconfig.Config{
+		b := Config{
 			Env: property.Properties{
 				{Key: "b", Value: "c"},
 			},
@@ -101,40 +100,40 @@ func TestConfig_Equal(t *testing.T) {
 	})
 
 	t.Run("equal_includes", func(t *testing.T) {
-		a := fluentbitconfig.Config{
+		a := Config{
 			Includes: []string{"foo"},
 		}
-		b := fluentbitconfig.Config{
+		b := Config{
 			Includes: []string{"foo"},
 		}
 		assert.True(t, a.Equal(b))
 	})
 
 	t.Run("not_equal_includes", func(t *testing.T) {
-		a := fluentbitconfig.Config{
+		a := Config{
 			Includes: []string{"foo"},
 		}
-		b := fluentbitconfig.Config{
+		b := Config{
 			Includes: []string{"bar"},
 		}
 		assert.False(t, a.Equal(b))
 	})
 
 	t.Run("equal_input", func(t *testing.T) {
-		a := fluentbitconfig.Config{
-			Pipeline: fluentbitconfig.Pipeline{
-				Inputs: []fluentbitconfig.ByName{{
-					"dummy": property.Properties{
+		a := Config{
+			Pipeline: Pipeline{
+				Inputs: Plugins{{
+					Properties: property.Properties{
 						{Key: "name", Value: "dummy"},
 						{Key: "rate", Value: 10},
 					}},
 				},
 			},
 		}
-		b := fluentbitconfig.Config{
-			Pipeline: fluentbitconfig.Pipeline{
-				Inputs: []fluentbitconfig.ByName{{
-					"dummy": property.Properties{
+		b := Config{
+			Pipeline: Pipeline{
+				Inputs: Plugins{{
+					Properties: property.Properties{
 						{Key: "name", Value: "dummy"},
 						{Key: "rate", Value: 10},
 					}},
@@ -145,20 +144,20 @@ func TestConfig_Equal(t *testing.T) {
 	})
 
 	t.Run("not_equal_input", func(t *testing.T) {
-		a := fluentbitconfig.Config{
-			Pipeline: fluentbitconfig.Pipeline{
-				Inputs: []fluentbitconfig.ByName{{
-					"dummy": property.Properties{
+		a := Config{
+			Pipeline: Pipeline{
+				Inputs: Plugins{{
+					Properties: property.Properties{
 						{Key: "name", Value: "dummy"},
 						{Key: "rate", Value: 10},
 					}},
 				},
 			},
 		}
-		b := fluentbitconfig.Config{
-			Pipeline: fluentbitconfig.Pipeline{
-				Inputs: []fluentbitconfig.ByName{{
-					"dummy": property.Properties{
+		b := Config{
+			Pipeline: Pipeline{
+				Inputs: Plugins{{
+					Properties: property.Properties{
 						{Key: "name", Value: "dummy"},
 						{Key: "rate", Value: 22},
 					}},
@@ -169,20 +168,20 @@ func TestConfig_Equal(t *testing.T) {
 	})
 
 	t.Run("not_equal_properties_out_of_order", func(t *testing.T) {
-		a := fluentbitconfig.Config{
-			Pipeline: fluentbitconfig.Pipeline{
-				Inputs: []fluentbitconfig.ByName{{
-					"foo": property.Properties{
+		a := Config{
+			Pipeline: Pipeline{
+				Inputs: Plugins{{
+					Properties: property.Properties{
 						{Key: "name", Value: "foo"},
 						{Key: "test_key", Value: "test_value"},
 					}},
 				},
 			},
 		}
-		b := fluentbitconfig.Config{
-			Pipeline: fluentbitconfig.Pipeline{
-				Inputs: []fluentbitconfig.ByName{{
-					"foo": property.Properties{
+		b := Config{
+			Pipeline: Pipeline{
+				Inputs: Plugins{{
+					Properties: property.Properties{
 						{Key: "test_key", Value: "test_value"},
 						{Key: "name", Value: "foo"},
 					}},
@@ -193,25 +192,25 @@ func TestConfig_Equal(t *testing.T) {
 	})
 
 	t.Run("not_equal_by_names_out_of_order", func(t *testing.T) {
-		a := fluentbitconfig.Config{
-			Pipeline: fluentbitconfig.Pipeline{
-				Inputs: []fluentbitconfig.ByName{{
-					"one": property.Properties{
+		a := Config{
+			Pipeline: Pipeline{
+				Inputs: Plugins{{
+					Properties: property.Properties{
 						{Key: "name", Value: "one"},
 					}}, {
-					"two": property.Properties{
+					Properties: property.Properties{
 						{Key: "name", Value: "two"},
 					}},
 				},
 			},
 		}
-		b := fluentbitconfig.Config{
-			Pipeline: fluentbitconfig.Pipeline{
-				Inputs: []fluentbitconfig.ByName{{
-					"two": property.Properties{
+		b := Config{
+			Pipeline: Pipeline{
+				Inputs: Plugins{{
+					Properties: property.Properties{
 						{Key: "name", Value: "two"},
-					},
-					"one": property.Properties{
+					}}, {
+					Properties: property.Properties{
 						{Key: "name", Value: "one"},
 					}},
 				},
@@ -223,16 +222,16 @@ func TestConfig_Equal(t *testing.T) {
 
 func TestConfig_IDs(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		conf, err := fluentbitconfig.ParseAs(`
+		conf, err := ParseAs(`
 			[SERVICE]
 				log_level error
-		`, fluentbitconfig.FormatClassic)
+		`, FormatClassic)
 		assert.NoError(t, err)
-		assert.Equal(t, nil, conf.IDs(true))
+		assert.Equal(t, nil, conf.IDs())
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		conf, err := fluentbitconfig.ParseAs(`
+		conf, err := ParseAs(`
 			[INPUT]
 				name tcp
 			[OUTPUT]
@@ -241,17 +240,17 @@ func TestConfig_IDs(t *testing.T) {
 			[OUTPUT]
 				name  stdout
 				match *
-		`, fluentbitconfig.FormatClassic)
+		`, FormatClassic)
 		assert.NoError(t, err)
 		assert.Equal(t, []string{
 			"input:tcp:tcp.0",
 			"output:tcp:tcp.0",
 			"output:stdout:stdout.1",
-		}, conf.IDs(true))
+		}, conf.IDs())
 	})
 
 	t.Run("ok_2", func(t *testing.T) {
-		conf, err := fluentbitconfig.ParseAs(`
+		conf, err := ParseAs(`
 			[INPUT]
 				name tcp
 			[OUTPUT]
@@ -260,31 +259,12 @@ func TestConfig_IDs(t *testing.T) {
 			[OUTPUT]
 				name  tcp
 				match *
-		`, fluentbitconfig.FormatClassic)
+		`, FormatClassic)
 		assert.NoError(t, err)
 		assert.Equal(t, []string{
 			"input:tcp:tcp.0",
 			"output:stdout:stdout.0",
 			"output:tcp:tcp.1",
-		}, conf.IDs(true))
-	})
-
-	t.Run("ok_no_prefix", func(t *testing.T) {
-		conf, err := fluentbitconfig.ParseAs(`
-			[INPUT]
-				name tcp
-			[OUTPUT]
-				name  tcp
-				match *
-			[OUTPUT]
-				name  stdout
-				match *
-		`, fluentbitconfig.FormatClassic)
-		assert.NoError(t, err)
-		assert.Equal(t, []string{
-			"tcp.0",
-			"tcp.0",
-			"stdout.1",
-		}, conf.IDs(false))
+		}, conf.IDs())
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
-module github.com/calyptia/go-fluentbit-config
+module github.com/calyptia/go-fluentbit-config/v2
 
-go 1.19
+go 1.20
 
 require (
-	github.com/alecthomas/assert/v2 v2.2.1
-	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
+	github.com/alecthomas/assert/v2 v2.2.2
+	golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
-github.com/alecthomas/assert/v2 v2.2.1 h1:XivOgYcduV98QCahG8T5XTezV5bylXe+lBxLG2K2ink=
-github.com/alecthomas/assert/v2 v2.2.1/go.mod h1:pXcQ2Asjp247dahGEmsZ6ru0UVwnkhktn7S0bBDLxvQ=
+github.com/alecthomas/assert/v2 v2.2.2 h1:Z/iVC0xZfWTaFNE6bA3z07T86hd45Xe2eLt6WVy2bbk=
+github.com/alecthomas/assert/v2 v2.2.2/go.mod h1:pXcQ2Asjp247dahGEmsZ6ru0UVwnkhktn7S0bBDLxvQ=
 github.com/alecthomas/repr v0.2.0 h1:HAzS41CIzNW5syS8Mf9UwXhNH1J9aix/BvDRf1Ml2Yk=
 github.com/alecthomas/repr v0.2.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
-golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 h1:Jvc7gsqn21cJHCmAWx0LiimpP18LZmUxkT5Mp7EZ1mI=
-golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0 h1:pVgRXcIictcr+lBQIFeiwuwtDIs4eL21OuM9nyAADmo=
+golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/networking/protocol.go
+++ b/networking/protocol.go
@@ -1,0 +1,13 @@
+package networking
+
+type Protocol string
+
+const (
+	ProtocolTCP  Protocol = "TCP"
+	ProtocolUDP  Protocol = "UDP"
+	ProtocolSCTP Protocol = "SCTP"
+)
+
+func (p Protocol) OK() bool {
+	return p == ProtocolTCP || p == ProtocolUDP || p == ProtocolSCTP
+}

--- a/plugin.go
+++ b/plugin.go
@@ -1,0 +1,115 @@
+package fluentbitconfig
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/calyptia/go-fluentbit-config/v2/property"
+	"golang.org/x/exp/slices"
+	"gopkg.in/yaml.v3"
+)
+
+type Plugins []Plugin
+
+func (plugins Plugins) IDs() []string {
+	var ids []string
+	for _, plugin := range plugins {
+		ids = append(ids, plugin.ID)
+	}
+	return ids
+}
+
+func (c Config) IDs() []string {
+	var ids []string
+	set := func(kind SectionKind, plugins Plugins) {
+		for _, plugin := range plugins {
+			ids = append(ids, fmt.Sprintf("%s:%s:%s", kind, plugin.Name, plugin.ID))
+		}
+	}
+
+	set(SectionKindCustom, c.Customs)
+	set(SectionKindInput, c.Pipeline.Inputs)
+	set(SectionKindParser, c.Pipeline.Parsers)
+	set(SectionKindFilter, c.Pipeline.Filters)
+	set(SectionKindOutput, c.Pipeline.Outputs)
+
+	return ids
+}
+
+func (plugins *Plugins) UnmarshalJSON(data []byte) error {
+	var dest []Plugin
+	err := json.Unmarshal(data, &dest)
+	if err != nil {
+		return err
+	}
+
+	*plugins = dest
+
+	for i, plugin := range *plugins {
+		plugin.ID = fmt.Sprintf("%s.%d", plugin.Name, i)
+		(*plugins)[i] = plugin
+	}
+
+	return nil
+}
+
+func (plugins *Plugins) UnmarshalYAML(node *yaml.Node) error {
+	var dest []Plugin
+	err := node.Decode(&dest)
+	if err != nil {
+		return err
+	}
+
+	*plugins = dest
+
+	for i, plugin := range *plugins {
+		plugin.ID = fmt.Sprintf("%s.%d", plugin.Name, i)
+		(*plugins)[i] = plugin
+	}
+
+	return nil
+}
+
+type Plugin struct {
+	ID         string              `json:"-" yaml:"-"`
+	Name       string              `json:"-" yaml:"-"`
+	Properties property.Properties `json:",inline" yaml:",inline"`
+}
+
+func (p Plugin) MarshalJSON() ([]byte, error) {
+	return p.Properties.MarshalJSON()
+}
+
+func (p Plugin) MarshalYAML() (any, error) {
+	return p.Properties.MarshalYAML()
+}
+
+func (p *Plugin) UnmarshalJSON(data []byte) error {
+	err := p.Properties.UnmarshalJSON(data)
+	if err != nil {
+		return err
+	}
+
+	p.Name = Name(p.Properties)
+	return nil
+}
+
+func (p *Plugin) UnmarshalYAML(node *yaml.Node) error {
+	err := p.Properties.UnmarshalYAML(node)
+	if err != nil {
+		return err
+	}
+
+	p.Name = Name(p.Properties)
+	return nil
+}
+
+func (p Plugin) Equal(target Plugin) bool {
+	return p.Properties.Equal(target.Properties)
+}
+
+func (plugins Plugins) Equal(target Plugins) bool {
+	return slices.EqualFunc(plugins, target, func(a, b Plugin) bool {
+		return a.Equal(b)
+	})
+}

--- a/plugin.go
+++ b/plugin.go
@@ -4,13 +4,16 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/calyptia/go-fluentbit-config/v2/property"
 	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
+
+	"github.com/calyptia/go-fluentbit-config/v2/property"
 )
 
 type Plugins []Plugin
 
+// IDs not namespaced.
+// For example: tail.0
 func (plugins Plugins) IDs() []string {
 	var ids []string
 	for _, plugin := range plugins {
@@ -19,21 +22,15 @@ func (plugins Plugins) IDs() []string {
 	return ids
 }
 
-func (c Config) IDs() []string {
-	var ids []string
-	set := func(kind SectionKind, plugins Plugins) {
-		for _, plugin := range plugins {
-			ids = append(ids, fmt.Sprintf("%s:%s:%s", kind, plugin.Name, plugin.ID))
+// FindByID were the id should not be namespaced.
+// For example: tail.0
+func (plugins Plugins) FindByID(id string) (Plugin, bool) {
+	for _, plugin := range plugins {
+		if plugin.ID == id {
+			return plugin, true
 		}
 	}
-
-	set(SectionKindCustom, c.Customs)
-	set(SectionKindInput, c.Pipeline.Inputs)
-	set(SectionKindParser, c.Pipeline.Parsers)
-	set(SectionKindFilter, c.Pipeline.Filters)
-	set(SectionKindOutput, c.Pipeline.Outputs)
-
-	return ids
+	return Plugin{}, false
 }
 
 func (plugins *Plugins) UnmarshalJSON(data []byte) error {

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1,0 +1,67 @@
+package fluentbitconfig
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+
+	"github.com/calyptia/go-fluentbit-config/v2/property"
+)
+
+func TestPlugins_IDs(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		conf, err := ParseAs(`
+			[INPUT]
+				name cpu
+			[INPUT]
+				name mem
+			[INPUT]
+				name  cpu
+		`, FormatClassic)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{
+			"cpu.0",
+			"mem.1",
+			"cpu.2",
+		}, conf.Pipeline.Inputs.IDs())
+	})
+}
+
+func TestPlugins_FindByID(t *testing.T) {
+	t.Run("not_found", func(t *testing.T) {
+		conf, err := ParseAs(`
+			[INPUT]
+				name cpu
+			[INPUT]
+				name mem
+			[INPUT]
+				name  cpu
+		`, FormatClassic)
+		assert.NoError(t, err)
+		_, found := conf.Pipeline.Inputs.FindByID("cpu.1")
+		assert.False(t, found)
+	})
+
+	t.Run("ok", func(t *testing.T) {
+		conf, err := ParseAs(`
+			[INPUT]
+				name cpu
+			[INPUT]
+				name mem
+			[INPUT]
+				name     cpu
+				proptest valuetest
+		`, FormatClassic)
+		assert.NoError(t, err)
+		plugin, found := conf.Pipeline.Inputs.FindByID("cpu.2")
+		assert.True(t, found)
+		assert.Equal(t, Plugin{
+			ID:   "cpu.2",
+			Name: "cpu",
+			Properties: []property.Property{
+				{Key: "name", Value: "cpu"},
+				{Key: "proptest", Value: "valuetest"},
+			},
+		}, plugin)
+	})
+}

--- a/ports.go
+++ b/ports.go
@@ -1,0 +1,183 @@
+package fluentbitconfig
+
+import (
+	"strconv"
+	"strings"
+
+	"golang.org/x/exp/slices"
+)
+
+var fluentBitNetworkingPorts = map[string]portDefault{
+	// Inputs.
+	"collectd":      {Number: 25826, Protocol: "udp"},
+	"elasticsearch": {Number: 9200, Protocol: "http"},
+	"forward":       {Number: 24224, Protocol: "http"}, // only if `unix_path` is not set.
+	"http":          {Number: 9880, Protocol: "http"},
+	"mqtt":          {Number: 1883, Protocol: "http"},
+	"opentelemetry": {Number: 4318, Protocol: "http"},
+	"statsd":        {Number: 8125, Protocol: "udp"},
+	"syslog":        {Number: 5140, Protocol: "udp"}, // only if `mode` is not `unix_udp` (default) or `unix_tcp`
+	"tcp":           {Number: 5170, Protocol: "tcp"},
+	"udp":           {Number: 5170, Protocol: "udp"},
+
+	// Outputs.
+	"prometheus_exporter": {Number: 2021, Protocol: "http"},
+}
+
+type portDefault struct {
+	Number   int
+	Protocol string
+}
+
+type Port struct {
+	Number   int
+	Protocol string
+	Kind     SectionKind
+	Plugin   *PortPlugin
+}
+
+type PortPlugin struct {
+	ID   string
+	Name string
+}
+
+type Ports []Port
+
+func (p Ports) Numbers() []int {
+	var out []int
+	for _, port := range p {
+		out = append(out, port.Number)
+	}
+
+	slices.Sort(out)
+	out = slices.Compact(out)
+
+	return out
+}
+
+func (c *Config) Ports() Ports {
+	var out Ports
+
+	enabledVal, ok := c.Service.Get("http_server")
+	if ok && (enabledVal == true || strings.ToLower(stringFromAny(enabledVal)) == "on") {
+		portVal, ok := c.Service.Get("http_port")
+		if !ok {
+			out = append(out, Port{
+				Number:   2020,
+				Protocol: "http",
+				Kind:     SectionKindService,
+			})
+		} else if i, ok := intFromAny(portVal); ok {
+			out = append(out, Port{
+				Number:   i,
+				Protocol: "http",
+				Kind:     SectionKindService,
+			})
+		}
+	}
+
+	lookup := func(kind SectionKind, plugins Plugins) {
+		for _, plugin := range plugins {
+			if plugin.Name == "forward" && plugin.Properties.Has("unix_path") {
+				continue
+			}
+
+			if plugin.Name == "syslog" {
+				modeVal, ok := plugin.Properties.Get("mode")
+				if !ok {
+					continue
+				}
+
+				if ok {
+					mode := strings.ToLower(stringFromAny(modeVal))
+					if mode == "unix_udp" || mode == "unix_tcp" {
+						continue
+					}
+				}
+			}
+
+			portVal, ok := plugin.Properties.Get("port")
+			if !ok {
+				defaultPort, ok := fluentBitNetworkingPorts[plugin.Name]
+				if ok {
+					out = append(out, Port{
+						Number:   defaultPort.Number,
+						Protocol: defaultPort.Protocol,
+						Kind:     kind,
+						Plugin: &PortPlugin{
+							ID:   plugin.ID,
+							Name: plugin.Name,
+						},
+					})
+				}
+			}
+
+			if ok {
+				port, ok := intFromAny(portVal)
+				if ok {
+					var protocol string
+					if plugin.Name == "syslog" {
+						modeVal, ok := plugin.Properties.Get("mode")
+						if ok {
+							protocol = strings.ToLower(stringFromAny(modeVal))
+						}
+					}
+
+					if protocol == "" {
+						defaultPort, ok := fluentBitNetworkingPorts[plugin.Name]
+						if ok {
+							protocol = defaultPort.Protocol
+						}
+					}
+
+					if protocol == "" {
+						protocol = "http"
+					}
+
+					out = append(out, Port{
+						Number:   port,
+						Protocol: protocol,
+						Kind:     kind,
+						Plugin: &PortPlugin{
+							ID:   plugin.ID,
+							Name: plugin.Name,
+						},
+					})
+				}
+			}
+		}
+	}
+
+	lookup(SectionKindInput, c.Pipeline.Inputs)
+	lookup(SectionKindOutput, c.Pipeline.Outputs)
+
+	return out
+}
+
+func intFromAny(v any) (int, bool) {
+	if v == nil {
+		return 0, false
+	}
+
+	switch v := v.(type) {
+	case int:
+		return v, true
+	case int32:
+		return int(v), true
+	case int64:
+		if int64(int(v)) == v {
+			return int(v), true
+		}
+	case float32:
+		return int(v), true
+	case float64:
+		if float64(int(v)) == v {
+			return int(v), true
+		}
+	case string:
+		if i, err := strconv.Atoi(v); err == nil {
+			return i, true
+		}
+	}
+	return 0, false
+}

--- a/ports.go
+++ b/ports.go
@@ -43,12 +43,8 @@ type ServicePort struct {
 	Port     int
 	Protocol Protocol
 	Kind     SectionKind
-	Plugin   *ServicePortPlugin
-}
-
-type ServicePortPlugin struct {
-	ID   string
-	Name string
+	// Plugin is not available for `service`` section kind.
+	Plugin *Plugin
 }
 
 type ServicePorts []ServicePort
@@ -98,14 +94,13 @@ func (c *Config) ServicePorts() ServicePorts {
 			if !ok {
 				defaults, ok := fluentBitNetworkingDefaults[plugin.Name]
 				if ok {
+					plugin := plugin
+					plugin.Properties = nil
 					out = append(out, ServicePort{
 						Port:     defaults.Port,
 						Protocol: defaults.Protocol,
 						Kind:     kind,
-						Plugin: &ServicePortPlugin{
-							ID:   plugin.ID,
-							Name: plugin.Name,
-						},
+						Plugin:   &plugin,
 					})
 				}
 			}
@@ -134,14 +129,13 @@ func (c *Config) ServicePorts() ServicePorts {
 						protocol = ProtocolTCP
 					}
 
+					plugin := plugin
+					plugin.Properties = nil
 					out = append(out, ServicePort{
 						Port:     port,
 						Protocol: protocol,
 						Kind:     kind,
-						Plugin: &ServicePortPlugin{
-							ID:   plugin.ID,
-							Name: plugin.Name,
-						},
+						Plugin:   &plugin,
 					})
 				}
 			}

--- a/ports_test.go
+++ b/ports_test.go
@@ -1,0 +1,146 @@
+package fluentbitconfig
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+func TestConfig_Ports(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		config, err := ParseAs(`
+			[SERVICE]
+				http_server on
+			[INPUT]
+				name collectd
+			[INPUT]
+				name elasticsearch
+			[INPUT]
+				name forward
+			[INPUT]
+				name http
+			[INPUT]
+				name mqtt
+			[INPUT]
+				name opentelemetry
+			[INPUT]
+				name statsd
+			[INPUT]
+				name syslog
+				mode udp
+			[INPUT]
+				name tcp
+			[INPUT]
+				name udp
+			[OUTPUT]
+				name prometheus_exporter
+		`, FormatClassic)
+		assert.NoError(t, err)
+		assert.Equal(t, Ports{
+			{Number: 2020, Protocol: "http", Kind: SectionKindService},
+			{Number: 25826, Protocol: "udp", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "collectd.0", Name: "collectd"}},
+			{Number: 9200, Protocol: "http", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "elasticsearch.1", Name: "elasticsearch"}},
+			{Number: 24224, Protocol: "http", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "forward.2", Name: "forward"}},
+			{Number: 9880, Protocol: "http", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "http.3", Name: "http"}},
+			{Number: 1883, Protocol: "http", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "mqtt.4", Name: "mqtt"}},
+			{Number: 4318, Protocol: "http", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "opentelemetry.5", Name: "opentelemetry"}},
+			{Number: 8125, Protocol: "udp", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "statsd.6", Name: "statsd"}},
+			{Number: 5140, Protocol: "udp", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "syslog.7", Name: "syslog"}},
+			{Number: 5170, Protocol: "tcp", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "tcp.8", Name: "tcp"}},
+			{Number: 5170, Protocol: "udp", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "udp.9", Name: "udp"}},
+			{Number: 2021, Protocol: "http", Kind: SectionKindOutput, Plugin: &PortPlugin{ID: "prometheus_exporter.0", Name: "prometheus_exporter"}},
+		}, config.Ports())
+	})
+
+	t.Run("explicit", func(t *testing.T) {
+		config, err := ParseAs(`
+			[SERVICE]
+				http_server on
+				http_port 1
+			[INPUT]
+				name collectd
+				port 2
+			[INPUT]
+				name elasticsearch
+				port 3
+			[INPUT]
+				name forward
+				port 4
+			[INPUT]
+				name http
+				port 5
+			[INPUT]
+				name mqtt
+				port 6
+			[INPUT]
+				name opentelemetry
+				port 7
+			[INPUT]
+				name statsd
+				port 8
+			[INPUT]
+				name syslog
+				mode udp
+				port 9
+			[INPUT]
+				name tcp
+				port 10
+			[INPUT]
+				name udp
+				port 11
+			[OUTPUT]
+				name prometheus_exporter
+				port 12
+		`, FormatClassic)
+		assert.NoError(t, err)
+		assert.Equal(t, []int{
+			1,
+			2,
+			3,
+			4,
+			5,
+			6,
+			7,
+			8,
+			9,
+			10,
+			11,
+			12,
+		}, config.Ports().Numbers())
+	})
+
+	t.Run("skips", func(t *testing.T) {
+		config, err := ParseAs(`
+			[INPUT]
+				name forward
+				unix_path /tmp/forward.sock
+				port 1
+			[INPUT]
+				name syslog
+				port 2
+			[INPUT]
+				name syslog
+				mode unix_udp
+				port 3
+			[INPUT]
+				name syslog
+				mode unix_tcp
+				port 4
+		`, FormatClassic)
+		assert.NoError(t, err)
+		assert.Equal(t, nil, config.Ports())
+	})
+
+	t.Run("with_mode", func(t *testing.T) {
+		config, err := ParseAs(`
+			[INPUT]
+				name syslog
+				mode tcp
+				port 1
+		`, FormatClassic)
+		assert.NoError(t, err)
+		assert.Equal(t, Ports{
+			{Number: 1, Protocol: "tcp", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "syslog.0", Name: "syslog"}},
+		}, config.Ports())
+	})
+}

--- a/ports_test.go
+++ b/ports_test.go
@@ -38,17 +38,17 @@ func TestConfig_Ports(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, ServicePorts{
 			{Port: 2020, Protocol: ProtocolTCP, Kind: SectionKindService},
-			{Port: 25826, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "collectd.0", Name: "collectd"}},
-			{Port: 9200, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "elasticsearch.1", Name: "elasticsearch"}},
-			{Port: 24224, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "forward.2", Name: "forward"}},
-			{Port: 9880, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "http.3", Name: "http"}},
-			{Port: 1883, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "mqtt.4", Name: "mqtt"}},
-			{Port: 4318, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "opentelemetry.5", Name: "opentelemetry"}},
-			{Port: 8125, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "statsd.6", Name: "statsd"}},
-			{Port: 5140, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "syslog.7", Name: "syslog"}},
-			{Port: 5170, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "tcp.8", Name: "tcp"}},
-			{Port: 5170, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "udp.9", Name: "udp"}},
-			{Port: 2021, Protocol: ProtocolTCP, Kind: SectionKindOutput, Plugin: &ServicePortPlugin{ID: "prometheus_exporter.0", Name: "prometheus_exporter"}},
+			{Port: 25826, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "collectd.0", Name: "collectd"}},
+			{Port: 9200, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "elasticsearch.1", Name: "elasticsearch"}},
+			{Port: 24224, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "forward.2", Name: "forward"}},
+			{Port: 9880, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "http.3", Name: "http"}},
+			{Port: 1883, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "mqtt.4", Name: "mqtt"}},
+			{Port: 4318, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "opentelemetry.5", Name: "opentelemetry"}},
+			{Port: 8125, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "statsd.6", Name: "statsd"}},
+			{Port: 5140, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "syslog.7", Name: "syslog"}},
+			{Port: 5170, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "tcp.8", Name: "tcp"}},
+			{Port: 5170, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "udp.9", Name: "udp"}},
+			{Port: 2021, Protocol: ProtocolTCP, Kind: SectionKindOutput, Plugin: &Plugin{ID: "prometheus_exporter.0", Name: "prometheus_exporter"}},
 		}, config.ServicePorts())
 	})
 
@@ -95,17 +95,17 @@ func TestConfig_Ports(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, ServicePorts{
 			{Port: 1, Protocol: ProtocolTCP, Kind: SectionKindService},
-			{Port: 2, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "collectd.0", Name: "collectd"}},
-			{Port: 3, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "elasticsearch.1", Name: "elasticsearch"}},
-			{Port: 4, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "forward.2", Name: "forward"}},
-			{Port: 5, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "http.3", Name: "http"}},
-			{Port: 6, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "mqtt.4", Name: "mqtt"}},
-			{Port: 7, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "opentelemetry.5", Name: "opentelemetry"}},
-			{Port: 8, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "statsd.6", Name: "statsd"}},
-			{Port: 9, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "syslog.7", Name: "syslog"}},
-			{Port: 10, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "tcp.8", Name: "tcp"}},
-			{Port: 11, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "udp.9", Name: "udp"}},
-			{Port: 12, Protocol: ProtocolTCP, Kind: SectionKindOutput, Plugin: &ServicePortPlugin{ID: "prometheus_exporter.0", Name: "prometheus_exporter"}},
+			{Port: 2, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "collectd.0", Name: "collectd"}},
+			{Port: 3, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "elasticsearch.1", Name: "elasticsearch"}},
+			{Port: 4, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "forward.2", Name: "forward"}},
+			{Port: 5, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "http.3", Name: "http"}},
+			{Port: 6, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "mqtt.4", Name: "mqtt"}},
+			{Port: 7, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "opentelemetry.5", Name: "opentelemetry"}},
+			{Port: 8, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "statsd.6", Name: "statsd"}},
+			{Port: 9, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "syslog.7", Name: "syslog"}},
+			{Port: 10, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "tcp.8", Name: "tcp"}},
+			{Port: 11, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "udp.9", Name: "udp"}},
+			{Port: 12, Protocol: ProtocolTCP, Kind: SectionKindOutput, Plugin: &Plugin{ID: "prometheus_exporter.0", Name: "prometheus_exporter"}},
 		}, config.ServicePorts())
 	})
 
@@ -140,7 +140,7 @@ func TestConfig_Ports(t *testing.T) {
 		`, FormatClassic)
 		assert.NoError(t, err)
 		assert.Equal(t, ServicePorts{
-			{Port: 1, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "syslog.0", Name: "syslog"}},
+			{Port: 1, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "syslog.0", Name: "syslog"}},
 		}, config.ServicePorts())
 	})
 }

--- a/ports_test.go
+++ b/ports_test.go
@@ -36,20 +36,20 @@ func TestConfig_Ports(t *testing.T) {
 				name prometheus_exporter
 		`, FormatClassic)
 		assert.NoError(t, err)
-		assert.Equal(t, Ports{
-			{Number: 2020, Protocol: "http", Kind: SectionKindService},
-			{Number: 25826, Protocol: "udp", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "collectd.0", Name: "collectd"}},
-			{Number: 9200, Protocol: "http", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "elasticsearch.1", Name: "elasticsearch"}},
-			{Number: 24224, Protocol: "http", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "forward.2", Name: "forward"}},
-			{Number: 9880, Protocol: "http", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "http.3", Name: "http"}},
-			{Number: 1883, Protocol: "http", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "mqtt.4", Name: "mqtt"}},
-			{Number: 4318, Protocol: "http", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "opentelemetry.5", Name: "opentelemetry"}},
-			{Number: 8125, Protocol: "udp", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "statsd.6", Name: "statsd"}},
-			{Number: 5140, Protocol: "udp", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "syslog.7", Name: "syslog"}},
-			{Number: 5170, Protocol: "tcp", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "tcp.8", Name: "tcp"}},
-			{Number: 5170, Protocol: "udp", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "udp.9", Name: "udp"}},
-			{Number: 2021, Protocol: "http", Kind: SectionKindOutput, Plugin: &PortPlugin{ID: "prometheus_exporter.0", Name: "prometheus_exporter"}},
-		}, config.Ports())
+		assert.Equal(t, ServicePorts{
+			{Port: 2020, Protocol: ProtocolTCP, Kind: SectionKindService},
+			{Port: 25826, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "collectd.0", Name: "collectd"}},
+			{Port: 9200, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "elasticsearch.1", Name: "elasticsearch"}},
+			{Port: 24224, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "forward.2", Name: "forward"}},
+			{Port: 9880, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "http.3", Name: "http"}},
+			{Port: 1883, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "mqtt.4", Name: "mqtt"}},
+			{Port: 4318, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "opentelemetry.5", Name: "opentelemetry"}},
+			{Port: 8125, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "statsd.6", Name: "statsd"}},
+			{Port: 5140, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "syslog.7", Name: "syslog"}},
+			{Port: 5170, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "tcp.8", Name: "tcp"}},
+			{Port: 5170, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "udp.9", Name: "udp"}},
+			{Port: 2021, Protocol: ProtocolTCP, Kind: SectionKindOutput, Plugin: &ServicePortPlugin{ID: "prometheus_exporter.0", Name: "prometheus_exporter"}},
+		}, config.ServicePorts())
 	})
 
 	t.Run("explicit", func(t *testing.T) {
@@ -93,20 +93,20 @@ func TestConfig_Ports(t *testing.T) {
 				port 12
 		`, FormatClassic)
 		assert.NoError(t, err)
-		assert.Equal(t, []int{
-			1,
-			2,
-			3,
-			4,
-			5,
-			6,
-			7,
-			8,
-			9,
-			10,
-			11,
-			12,
-		}, config.Ports().Numbers())
+		assert.Equal(t, ServicePorts{
+			{Port: 1, Protocol: ProtocolTCP, Kind: SectionKindService},
+			{Port: 2, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "collectd.0", Name: "collectd"}},
+			{Port: 3, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "elasticsearch.1", Name: "elasticsearch"}},
+			{Port: 4, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "forward.2", Name: "forward"}},
+			{Port: 5, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "http.3", Name: "http"}},
+			{Port: 6, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "mqtt.4", Name: "mqtt"}},
+			{Port: 7, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "opentelemetry.5", Name: "opentelemetry"}},
+			{Port: 8, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "statsd.6", Name: "statsd"}},
+			{Port: 9, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "syslog.7", Name: "syslog"}},
+			{Port: 10, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "tcp.8", Name: "tcp"}},
+			{Port: 11, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "udp.9", Name: "udp"}},
+			{Port: 12, Protocol: ProtocolTCP, Kind: SectionKindOutput, Plugin: &ServicePortPlugin{ID: "prometheus_exporter.0", Name: "prometheus_exporter"}},
+		}, config.ServicePorts())
 	})
 
 	t.Run("skips", func(t *testing.T) {
@@ -128,7 +128,7 @@ func TestConfig_Ports(t *testing.T) {
 				port 4
 		`, FormatClassic)
 		assert.NoError(t, err)
-		assert.Equal(t, nil, config.Ports())
+		assert.Equal(t, nil, config.ServicePorts())
 	})
 
 	t.Run("with_mode", func(t *testing.T) {
@@ -139,8 +139,8 @@ func TestConfig_Ports(t *testing.T) {
 				port 1
 		`, FormatClassic)
 		assert.NoError(t, err)
-		assert.Equal(t, Ports{
-			{Number: 1, Protocol: "tcp", Kind: SectionKindInput, Plugin: &PortPlugin{ID: "syslog.0", Name: "syslog"}},
-		}, config.Ports())
+		assert.Equal(t, ServicePorts{
+			{Port: 1, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &ServicePortPlugin{ID: "syslog.0", Name: "syslog"}},
+		}, config.ServicePorts())
 	})
 }

--- a/service_port.go
+++ b/service_port.go
@@ -6,7 +6,7 @@ import (
 	"github.com/calyptia/go-fluentbit-config/v2/networking"
 )
 
-var fluentBitNetworkingDefaults = map[string]servicePortDefaults{
+var servicePortDefaultsByPlugin = map[string]servicePortDefaults{
 	// Inputs.
 	"collectd":      {Port: 25826, Protocol: networking.ProtocolUDP},
 	"elasticsearch": {Port: 9200, Protocol: networking.ProtocolTCP},
@@ -81,7 +81,7 @@ func (c *Config) ServicePorts() ServicePorts {
 
 			portVal, ok := plugin.Properties.Get("port")
 			if !ok {
-				defaults, ok := fluentBitNetworkingDefaults[plugin.Name]
+				defaults, ok := servicePortDefaultsByPlugin[plugin.Name]
 				if ok {
 					plugin := plugin
 					plugin.Properties = nil
@@ -108,7 +108,7 @@ func (c *Config) ServicePorts() ServicePorts {
 					}
 
 					if protocol == "" {
-						defaultPort, ok := fluentBitNetworkingDefaults[plugin.Name]
+						defaultPort, ok := servicePortDefaultsByPlugin[plugin.Name]
 						if ok {
 							protocol = defaultPort.Protocol
 						}

--- a/service_port.go
+++ b/service_port.go
@@ -2,45 +2,35 @@ package fluentbitconfig
 
 import (
 	"strings"
+
+	"github.com/calyptia/go-fluentbit-config/v2/networking"
 )
-
-type Protocol string
-
-const (
-	ProtocolTCP  Protocol = "TCP"
-	ProtocolUDP  Protocol = "UDP"
-	ProtocolSCTP Protocol = "SCTP"
-)
-
-func (p Protocol) OK() bool {
-	return p == ProtocolTCP || p == ProtocolUDP || p == ProtocolSCTP
-}
 
 var fluentBitNetworkingDefaults = map[string]servicePortDefaults{
 	// Inputs.
-	"collectd":      {Port: 25826, Protocol: ProtocolUDP},
-	"elasticsearch": {Port: 9200, Protocol: ProtocolTCP},
-	"forward":       {Port: 24224, Protocol: ProtocolTCP}, // only if `unix_path` is not set.
-	"http":          {Port: 9880, Protocol: ProtocolTCP},
-	"mqtt":          {Port: 1883, Protocol: ProtocolTCP},
-	"opentelemetry": {Port: 4318, Protocol: ProtocolTCP},
-	"statsd":        {Port: 8125, Protocol: ProtocolUDP},
-	"syslog":        {Port: 5140, Protocol: ProtocolUDP}, // only if `mode` is not `unix_udp` (default) or `unix_tcp`
-	"tcp":           {Port: 5170, Protocol: ProtocolTCP},
-	"udp":           {Port: 5170, Protocol: ProtocolUDP},
+	"collectd":      {Port: 25826, Protocol: networking.ProtocolUDP},
+	"elasticsearch": {Port: 9200, Protocol: networking.ProtocolTCP},
+	"forward":       {Port: 24224, Protocol: networking.ProtocolTCP}, // only if `unix_path` is not set.
+	"http":          {Port: 9880, Protocol: networking.ProtocolTCP},
+	"mqtt":          {Port: 1883, Protocol: networking.ProtocolTCP},
+	"opentelemetry": {Port: 4318, Protocol: networking.ProtocolTCP},
+	"statsd":        {Port: 8125, Protocol: networking.ProtocolUDP},
+	"syslog":        {Port: 5140, Protocol: networking.ProtocolUDP}, // only if `mode` is not `unix_udp` (default) or `unix_tcp`
+	"tcp":           {Port: 5170, Protocol: networking.ProtocolTCP},
+	"udp":           {Port: 5170, Protocol: networking.ProtocolUDP},
 
 	// Outputs.
-	"prometheus_exporter": {Port: 2021, Protocol: ProtocolTCP},
+	"prometheus_exporter": {Port: 2021, Protocol: networking.ProtocolTCP},
 }
 
 type servicePortDefaults struct {
 	Port     int
-	Protocol Protocol
+	Protocol networking.Protocol
 }
 
 type ServicePort struct {
 	Port     int
-	Protocol Protocol
+	Protocol networking.Protocol
 	Kind     SectionKind
 	// Plugin is not available for `service`` section kind.
 	Plugin *Plugin
@@ -57,13 +47,13 @@ func (c *Config) ServicePorts() ServicePorts {
 		if !ok {
 			out = append(out, ServicePort{
 				Port:     2020,
-				Protocol: ProtocolTCP,
+				Protocol: networking.ProtocolTCP,
 				Kind:     SectionKindService,
 			})
 		} else if i, ok := intFromAny(portVal); ok {
 			out = append(out, ServicePort{
 				Port:     i,
-				Protocol: ProtocolTCP,
+				Protocol: networking.ProtocolTCP,
 				Kind:     SectionKindService,
 			})
 		}
@@ -107,11 +97,11 @@ func (c *Config) ServicePorts() ServicePorts {
 			if ok {
 				port, ok := intFromAny(portVal)
 				if ok {
-					var protocol Protocol
+					var protocol networking.Protocol
 					if plugin.Name == "syslog" {
 						modeVal, ok := plugin.Properties.Get("mode")
 						if ok {
-							if v := Protocol(strings.ToUpper(stringFromAny(modeVal))); v.OK() {
+							if v := networking.Protocol(strings.ToUpper(stringFromAny(modeVal))); v.OK() {
 								protocol = v
 							}
 						}
@@ -125,7 +115,7 @@ func (c *Config) ServicePorts() ServicePorts {
 					}
 
 					if protocol == "" {
-						protocol = ProtocolTCP
+						protocol = networking.ProtocolTCP
 					}
 
 					plugin := plugin

--- a/service_port.go
+++ b/service_port.go
@@ -1,7 +1,6 @@
 package fluentbitconfig
 
 import (
-	"strconv"
 	"strings"
 )
 
@@ -17,7 +16,7 @@ func (p Protocol) OK() bool {
 	return p == ProtocolTCP || p == ProtocolUDP || p == ProtocolSCTP
 }
 
-var fluentBitNetworkingDefaults = map[string]portDefault{
+var fluentBitNetworkingDefaults = map[string]servicePortDefaults{
 	// Inputs.
 	"collectd":      {Port: 25826, Protocol: ProtocolUDP},
 	"elasticsearch": {Port: 9200, Protocol: ProtocolTCP},
@@ -34,7 +33,7 @@ var fluentBitNetworkingDefaults = map[string]portDefault{
 	"prometheus_exporter": {Port: 2021, Protocol: ProtocolTCP},
 }
 
-type portDefault struct {
+type servicePortDefaults struct {
 	Port     int
 	Protocol Protocol
 }
@@ -146,32 +145,4 @@ func (c *Config) ServicePorts() ServicePorts {
 	lookup(SectionKindOutput, c.Pipeline.Outputs)
 
 	return out
-}
-
-func intFromAny(v any) (int, bool) {
-	if v == nil {
-		return 0, false
-	}
-
-	switch v := v.(type) {
-	case int:
-		return v, true
-	case int32:
-		return int(v), true
-	case int64:
-		if int64(int(v)) == v {
-			return int(v), true
-		}
-	case float32:
-		return int(v), true
-	case float64:
-		if float64(int(v)) == v {
-			return int(v), true
-		}
-	case string:
-		if i, err := strconv.Atoi(v); err == nil {
-			return i, true
-		}
-	}
-	return 0, false
 }

--- a/service_port_test.go
+++ b/service_port_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/alecthomas/assert/v2"
 )
 
-func TestConfig_Ports(t *testing.T) {
+func TestConfig_ServicePorts(t *testing.T) {
 	t.Run("defaults", func(t *testing.T) {
 		config, err := ParseAs(`
 			[SERVICE]

--- a/service_port_test.go
+++ b/service_port_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
+
 	"github.com/calyptia/go-fluentbit-config/v2/networking"
 )
 

--- a/service_port_test.go
+++ b/service_port_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
+	"github.com/calyptia/go-fluentbit-config/v2/networking"
 )
 
 func TestConfig_ServicePorts(t *testing.T) {
@@ -37,18 +38,18 @@ func TestConfig_ServicePorts(t *testing.T) {
 		`, FormatClassic)
 		assert.NoError(t, err)
 		assert.Equal(t, ServicePorts{
-			{Port: 2020, Protocol: ProtocolTCP, Kind: SectionKindService},
-			{Port: 25826, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "collectd.0", Name: "collectd"}},
-			{Port: 9200, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "elasticsearch.1", Name: "elasticsearch"}},
-			{Port: 24224, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "forward.2", Name: "forward"}},
-			{Port: 9880, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "http.3", Name: "http"}},
-			{Port: 1883, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "mqtt.4", Name: "mqtt"}},
-			{Port: 4318, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "opentelemetry.5", Name: "opentelemetry"}},
-			{Port: 8125, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "statsd.6", Name: "statsd"}},
-			{Port: 5140, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "syslog.7", Name: "syslog"}},
-			{Port: 5170, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "tcp.8", Name: "tcp"}},
-			{Port: 5170, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "udp.9", Name: "udp"}},
-			{Port: 2021, Protocol: ProtocolTCP, Kind: SectionKindOutput, Plugin: &Plugin{ID: "prometheus_exporter.0", Name: "prometheus_exporter"}},
+			{Port: 2020, Protocol: networking.ProtocolTCP, Kind: SectionKindService},
+			{Port: 25826, Protocol: networking.ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "collectd.0", Name: "collectd"}},
+			{Port: 9200, Protocol: networking.ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "elasticsearch.1", Name: "elasticsearch"}},
+			{Port: 24224, Protocol: networking.ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "forward.2", Name: "forward"}},
+			{Port: 9880, Protocol: networking.ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "http.3", Name: "http"}},
+			{Port: 1883, Protocol: networking.ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "mqtt.4", Name: "mqtt"}},
+			{Port: 4318, Protocol: networking.ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "opentelemetry.5", Name: "opentelemetry"}},
+			{Port: 8125, Protocol: networking.ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "statsd.6", Name: "statsd"}},
+			{Port: 5140, Protocol: networking.ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "syslog.7", Name: "syslog"}},
+			{Port: 5170, Protocol: networking.ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "tcp.8", Name: "tcp"}},
+			{Port: 5170, Protocol: networking.ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "udp.9", Name: "udp"}},
+			{Port: 2021, Protocol: networking.ProtocolTCP, Kind: SectionKindOutput, Plugin: &Plugin{ID: "prometheus_exporter.0", Name: "prometheus_exporter"}},
 		}, config.ServicePorts())
 	})
 
@@ -94,18 +95,18 @@ func TestConfig_ServicePorts(t *testing.T) {
 		`, FormatClassic)
 		assert.NoError(t, err)
 		assert.Equal(t, ServicePorts{
-			{Port: 1, Protocol: ProtocolTCP, Kind: SectionKindService},
-			{Port: 2, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "collectd.0", Name: "collectd"}},
-			{Port: 3, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "elasticsearch.1", Name: "elasticsearch"}},
-			{Port: 4, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "forward.2", Name: "forward"}},
-			{Port: 5, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "http.3", Name: "http"}},
-			{Port: 6, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "mqtt.4", Name: "mqtt"}},
-			{Port: 7, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "opentelemetry.5", Name: "opentelemetry"}},
-			{Port: 8, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "statsd.6", Name: "statsd"}},
-			{Port: 9, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "syslog.7", Name: "syslog"}},
-			{Port: 10, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "tcp.8", Name: "tcp"}},
-			{Port: 11, Protocol: ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "udp.9", Name: "udp"}},
-			{Port: 12, Protocol: ProtocolTCP, Kind: SectionKindOutput, Plugin: &Plugin{ID: "prometheus_exporter.0", Name: "prometheus_exporter"}},
+			{Port: 1, Protocol: networking.ProtocolTCP, Kind: SectionKindService},
+			{Port: 2, Protocol: networking.ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "collectd.0", Name: "collectd"}},
+			{Port: 3, Protocol: networking.ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "elasticsearch.1", Name: "elasticsearch"}},
+			{Port: 4, Protocol: networking.ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "forward.2", Name: "forward"}},
+			{Port: 5, Protocol: networking.ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "http.3", Name: "http"}},
+			{Port: 6, Protocol: networking.ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "mqtt.4", Name: "mqtt"}},
+			{Port: 7, Protocol: networking.ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "opentelemetry.5", Name: "opentelemetry"}},
+			{Port: 8, Protocol: networking.ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "statsd.6", Name: "statsd"}},
+			{Port: 9, Protocol: networking.ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "syslog.7", Name: "syslog"}},
+			{Port: 10, Protocol: networking.ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "tcp.8", Name: "tcp"}},
+			{Port: 11, Protocol: networking.ProtocolUDP, Kind: SectionKindInput, Plugin: &Plugin{ID: "udp.9", Name: "udp"}},
+			{Port: 12, Protocol: networking.ProtocolTCP, Kind: SectionKindOutput, Plugin: &Plugin{ID: "prometheus_exporter.0", Name: "prometheus_exporter"}},
 		}, config.ServicePorts())
 	})
 
@@ -140,7 +141,7 @@ func TestConfig_ServicePorts(t *testing.T) {
 		`, FormatClassic)
 		assert.NoError(t, err)
 		assert.Equal(t, ServicePorts{
-			{Port: 1, Protocol: ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "syslog.0", Name: "syslog"}},
+			{Port: 1, Protocol: networking.ProtocolTCP, Kind: SectionKindInput, Plugin: &Plugin{ID: "syslog.0", Name: "syslog"}},
 		}, config.ServicePorts())
 	})
 }

--- a/testdata/array-value.json
+++ b/testdata/array-value.json
@@ -2,13 +2,11 @@
     "pipeline": {
         "filters": [
             {
-                "record_modifier": {
-                    "name": "record_modifier",
-                    "record": [
-                        "key1 value1",
-                        "key2 value2"
-                    ]
-                }
+                "name": "record_modifier",
+                "record": [
+                    "key1 value1",
+                    "key2 value2"
+                ]
             }
         ]
     }

--- a/testdata/array-value.yaml
+++ b/testdata/array-value.yaml
@@ -1,7 +1,6 @@
 pipeline:
     filters:
-        - record_modifier:
-            name: record_modifier
-            record:
-                - key1 value1
-                - key2 value2
+        - name: record_modifier
+          record:
+            - key1 value1
+            - key2 value2

--- a/testdata/boolean-value.json
+++ b/testdata/boolean-value.json
@@ -2,10 +2,8 @@
     "pipeline": {
         "inputs": [
             {
-                "tail": {
-                    "name": "tail",
-                    "exit_on_eof": false
-                }
+                "name": "tail",
+                "exit_on_eof": false
             }
         ]
     }

--- a/testdata/boolean-value.yaml
+++ b/testdata/boolean-value.yaml
@@ -1,5 +1,4 @@
 pipeline:
     inputs:
-        - tail:
-            name: tail
-            exit_on_eof: false
+        - name: tail
+          exit_on_eof: false

--- a/testdata/custom.json
+++ b/testdata/custom.json
@@ -1,10 +1,8 @@
 {
     "customs": [
         {
-            "calyptia": {
-                "name": "calyptia",
-                "api_key": "secret"
-            }
+            "name": "calyptia",
+            "api_key": "secret"
         }
     ],
     "pipeline": {}

--- a/testdata/custom.yaml
+++ b/testdata/custom.yaml
@@ -1,4 +1,3 @@
 customs:
-    - calyptia:
-        name: calyptia
-        api_key: secret
+    - name: calyptia
+      api_key: secret

--- a/testdata/empty-string.json
+++ b/testdata/empty-string.json
@@ -1,10 +1,8 @@
 {
     "customs": [
         {
-            "empty_string": {
-                "name": "empty_string",
-                "value": ""
-            }
+            "name": "empty_string",
+            "value": ""
         }
     ],
     "pipeline": {}

--- a/testdata/empty-string.yaml
+++ b/testdata/empty-string.yaml
@@ -1,4 +1,3 @@
 customs:
-    - empty_string:
-        name: empty_string
-        value: ""
+    - name: empty_string
+      value: ""

--- a/testdata/example-cloud-files.json
+++ b/testdata/example-cloud-files.json
@@ -2,32 +2,26 @@
     "pipeline": {
         "inputs": [
             {
-                "{{files.name}}": {
-                    "NameA": "{{filesnote}}",
-                    "NameB": "{{files}}",
-                    "NameC": "{{files...}}",
-                    "NameD": "{{nofiles.test}}",
-                    "NameE": "{files.nope}",
-                    "Name": "{{files.name}}",
-                    "Listen": "{{files.testing}}",
-                    "Port": 24224
-                }
+                "NameA": "{{filesnote}}",
+                "NameB": "{{files}}",
+                "NameC": "{{files...}}",
+                "NameD": "{{nofiles.test}}",
+                "NameE": "{files.nope}",
+                "Name": "{{files.name}}",
+                "Listen": "{{files.testing}}",
+                "Port": 24224
             },
             {
-                "tail": {
-                    "Name": "tail",
-                    "Tag": "tail.01",
-                    "Path": "/var/log/system.log"
-                }
+                "Name": "tail",
+                "Tag": "tail.01",
+                "Path": "/var/log/system.log"
             }
         ],
         "outputs": [
             {
-                "s3": {
-                    "Name": "s3",
-                    "Match": "*",
-                    "bucket": "{{files.bucket}}"
-                }
+                "Name": "s3",
+                "Match": "*",
+                "bucket": "{{files.bucket}}"
             }
         ]
     }

--- a/testdata/example-cloud-files.yaml
+++ b/testdata/example-cloud-files.yaml
@@ -1,20 +1,17 @@
 pipeline:
     inputs:
-        - '{{files.name}}':
-            NameA: '{{filesnote}}'
-            NameB: '{{files}}'
-            NameC: '{{files...}}'
-            NameD: '{{nofiles.test}}'
-            NameE: '{files.nope}'
-            Name: '{{files.name}}'
-            Listen: '{{files.testing}}'
-            Port: 24224
-        - tail:
-            Name: tail
-            Tag: tail.01
-            Path: /var/log/system.log
+        - NameA: '{{filesnote}}'
+          NameB: '{{files}}'
+          NameC: '{{files...}}'
+          NameD: '{{nofiles.test}}'
+          NameE: '{files.nope}'
+          Name: '{{files.name}}'
+          Listen: '{{files.testing}}'
+          Port: 24224
+        - Name: tail
+          Tag: tail.01
+          Path: /var/log/system.log
     outputs:
-        - s3:
-            Name: s3
-            Match: '*'
-            bucket: '{{files.bucket}}'
+        - Name: s3
+          Match: '*'
+          bucket: '{{files.bucket}}'

--- a/testdata/example-multiline-parser.json
+++ b/testdata/example-multiline-parser.json
@@ -2,13 +2,11 @@
     "pipeline": {
         "inputs": [
             {
-                "tail": {
-                    "Name": "tail",
-                    "Path": "/var/log/containers/*.log",
-                    "Tag": "containers",
-                    "multiline.parser": "docker , cri",
-                    "Skip_Long_Lines": "On"
-                }
+                "Name": "tail",
+                "Path": "/var/log/containers/*.log",
+                "Tag": "containers",
+                "multiline.parser": "docker , cri",
+                "Skip_Long_Lines": "On"
             }
         ]
     }

--- a/testdata/example-multiline-parser.yaml
+++ b/testdata/example-multiline-parser.yaml
@@ -1,8 +1,7 @@
 pipeline:
     inputs:
-        - tail:
-            Name: tail
-            Path: /var/log/containers/*.log
-            Tag: containers
-            multiline.parser: docker , cri
-            Skip_Long_Lines: "On"
+        - Name: tail
+          Path: /var/log/containers/*.log
+          Tag: containers
+          multiline.parser: docker , cri
+          Skip_Long_Lines: "On"

--- a/testdata/example-nrlogs-base-uri.json
+++ b/testdata/example-nrlogs-base-uri.json
@@ -2,10 +2,8 @@
     "pipeline": {
         "outputs": [
             {
-                "nrlogs": {
-                    "name": "nrlogs",
-                    "base_uri": "https://log-api.newrelic.com/log/v1"
-                }
+                "name": "nrlogs",
+                "base_uri": "https://log-api.newrelic.com/log/v1"
             }
         ]
     }

--- a/testdata/example-nrlogs-base-uri.yaml
+++ b/testdata/example-nrlogs-base-uri.yaml
@@ -1,5 +1,4 @@
 pipeline:
     outputs:
-        - nrlogs:
-            name: nrlogs
-            base_uri: https://log-api.newrelic.com/log/v1
+        - name: nrlogs
+          base_uri: https://log-api.newrelic.com/log/v1

--- a/testdata/float-value.json
+++ b/testdata/float-value.json
@@ -2,10 +2,8 @@
     "pipeline": {
         "filters": [
             {
-                "throttle": {
-                    "name": "throttle",
-                    "rate": 3.14
-                }
+                "name": "throttle",
+                "rate": 3.14
             }
         ]
     }

--- a/testdata/float-value.yaml
+++ b/testdata/float-value.yaml
@@ -1,5 +1,4 @@
 pipeline:
     filters:
-        - throttle:
-            name: throttle
-            rate: 3.14
+        - name: throttle
+          rate: 3.14

--- a/testdata/full.json
+++ b/testdata/full.json
@@ -11,59 +11,45 @@
     },
     "customs": [
         {
-            "calyptia": {
-                "name": "calyptia",
-                "api_key": "secret"
-            }
+            "name": "calyptia",
+            "api_key": "secret"
         }
     ],
     "pipeline": {
         "inputs": [
             {
-                "syslog": {
-                    "name": "syslog",
-                    "listen": "0.0.0.0",
-                    "port": 5140
-                }
+                "name": "syslog",
+                "listen": "0.0.0.0",
+                "port": 5140
             },
             {
-                "tail": {
-                    "name": "tail",
-                    "exit_on_eof": false
-                }
+                "name": "tail",
+                "exit_on_eof": false
             },
             {
-                "dummy": {
-                    "name": "dummy",
-                    "dummy": "{\"message\": \"hello from fluent-bit\"}"
-                }
+                "name": "dummy",
+                "dummy": "{\"message\": \"hello from fluent-bit\"}"
             }
         ],
         "filters": [
             {
-                "throttle": {
-                    "name": "throttle",
-                    "match": "syslog",
-                    "rate": 3.14
-                }
+                "name": "throttle",
+                "match": "syslog",
+                "rate": 3.14
             },
             {
-                "record_modifier": {
-                    "name": "record_modifier",
-                    "match": "dummy",
-                    "record": [
-                        "key1 value1",
-                        "key2 value2"
-                    ]
-                }
+                "name": "record_modifier",
+                "match": "dummy",
+                "record": [
+                    "key1 value1",
+                    "key2 value2"
+                ]
             }
         ],
         "outputs": [
             {
-                "stdout": {
-                    "name": "stdout",
-                    "match": "*"
-                }
+                "name": "stdout",
+                "match": "*"
             }
         ]
     }

--- a/testdata/full.yaml
+++ b/testdata/full.yaml
@@ -7,33 +7,26 @@ service:
     log_level: error
     http_server: "on"
 customs:
-    - calyptia:
-        name: calyptia
-        api_key: secret
+    - name: calyptia
+      api_key: secret
 pipeline:
     inputs:
-        - syslog:
-            name: syslog
-            listen: 0.0.0.0
-            port: 5140
-        - tail:
-            name: tail
-            exit_on_eof: false
-        - dummy:
-            name: dummy
-            dummy: '{"message": "hello from fluent-bit"}'
+        - name: syslog
+          listen: 0.0.0.0
+          port: 5140
+        - name: tail
+          exit_on_eof: false
+        - name: dummy
+          dummy: '{"message": "hello from fluent-bit"}'
     filters:
-        - throttle:
-            name: throttle
-            match: syslog
-            rate: 3.14
-        - record_modifier:
-            name: record_modifier
-            match: dummy
-            record:
-                - key1 value1
-                - key2 value2
+        - name: throttle
+          match: syslog
+          rate: 3.14
+        - name: record_modifier
+          match: dummy
+          record:
+            - key1 value1
+            - key2 value2
     outputs:
-        - stdout:
-            name: stdout
-            match: '*'
+        - name: stdout
+          match: '*'

--- a/testdata/integer-value.json
+++ b/testdata/integer-value.json
@@ -2,10 +2,8 @@
     "pipeline": {
         "inputs": [
             {
-                "syslog": {
-                    "name": "syslog",
-                    "port": 5140
-                }
+                "name": "syslog",
+                "port": 5140
             }
         ]
     }

--- a/testdata/integer-value.yaml
+++ b/testdata/integer-value.yaml
@@ -1,5 +1,4 @@
 pipeline:
     inputs:
-        - syslog:
-            name: syslog
-            port: 5140
+        - name: syslog
+          port: 5140

--- a/testdata/json-value.json
+++ b/testdata/json-value.json
@@ -2,10 +2,8 @@
     "pipeline": {
         "inputs": [
             {
-                "dummy": {
-                    "name": "dummy",
-                    "dummy": "{\"message\": \"hello from fluent-bit\"}"
-                }
+                "name": "dummy",
+                "dummy": "{\"message\": \"hello from fluent-bit\"}"
             }
         ]
     }

--- a/testdata/json-value.yaml
+++ b/testdata/json-value.yaml
@@ -1,5 +1,4 @@
 pipeline:
     inputs:
-        - dummy:
-            name: dummy
-            dummy: '{"message": "hello from fluent-bit"}'
+        - name: dummy
+          dummy: '{"message": "hello from fluent-bit"}'

--- a/testdata/multiline-value.json
+++ b/testdata/multiline-value.json
@@ -1,10 +1,8 @@
 {
     "customs": [
         {
-            "custom": {
-                "name": "custom",
-                "multiline": "FOO\nBAR"
-            }
+            "name": "custom",
+            "multiline": "FOO\nBAR"
         }
     ],
     "pipeline": {}

--- a/testdata/multiline-value.yaml
+++ b/testdata/multiline-value.yaml
@@ -1,6 +1,5 @@
 customs:
-    - custom:
-        name: custom
-        multiline: |-
-            FOO
-            BAR
+    - name: custom
+      multiline: |-
+        FOO
+        BAR

--- a/testdata/parser.json
+++ b/testdata/parser.json
@@ -2,11 +2,9 @@
     "pipeline": {
         "parsers": [
             {
-                "dummy_test": {
-                    "name": "dummy_test",
-                    "format": "regex",
-                    "regex": "^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<STRING>.+)$"
-                }
+                "name": "dummy_test",
+                "format": "regex",
+                "regex": "^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<STRING>.+)$"
             }
         ]
     }

--- a/testdata/parser.yaml
+++ b/testdata/parser.yaml
@@ -1,6 +1,5 @@
 pipeline:
     parsers:
-        - dummy_test:
-            name: dummy_test
-            format: regex
-            regex: ^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<STRING>.+)$
+        - name: dummy_test
+          format: regex
+          regex: ^(?<INT>[^ ]+) (?<FLOAT>[^ ]+) (?<BOOL>[^ ]+) (?<STRING>.+)$

--- a/testdata/string-value.json
+++ b/testdata/string-value.json
@@ -2,10 +2,8 @@
     "pipeline": {
         "inputs": [
             {
-                "syslog": {
-                    "name": "syslog",
-                    "listen": "0.0.0.0"
-                }
+                "name": "syslog",
+                "listen": "0.0.0.0"
             }
         ]
     }

--- a/testdata/string-value.yaml
+++ b/testdata/string-value.yaml
@@ -1,5 +1,4 @@
 pipeline:
     inputs:
-        - syslog:
-            name: syslog
-            listen: 0.0.0.0
+        - name: syslog
+          listen: 0.0.0.0

--- a/utl.go
+++ b/utl.go
@@ -1,0 +1,131 @@
+package fluentbitconfig
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// anyFromString used to convert property values from the classic config
+// to any type.
+func anyFromString(s string) any {
+	// not using strconv since the boolean parser is not very strict
+	// and allows: 1, t, T, 0, f, F.
+	if strings.EqualFold(s, "true") {
+		return true
+	}
+
+	if strings.EqualFold(s, "false") {
+		return false
+	}
+
+	if v, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return v
+	}
+
+	if v, err := strconv.ParseFloat(s, 64); err == nil {
+		return v
+	}
+
+	if u, err := strconv.Unquote(s); err == nil {
+		return u
+	}
+
+	return s
+}
+
+// stringFromAny -
+// TODO: Handle more data types.
+func stringFromAny(v any) string {
+	switch t := v.(type) {
+	case encoding.TextMarshaler:
+		if b, err := t.MarshalText(); err == nil {
+			return stringFromAny(string(b))
+		}
+	case fmt.Stringer:
+		return stringFromAny(t.String())
+	case json.Marshaler:
+		if b, err := t.MarshalJSON(); err == nil {
+			return stringFromAny(string(b))
+		}
+	case map[string]any:
+		var buff bytes.Buffer
+		enc := json.NewEncoder(&buff)
+		enc.SetEscapeHTML(false)
+		if err := enc.Encode(t); err == nil {
+			return buff.String()
+		}
+	case float32:
+		if isFloatInt(t) {
+			return strconv.FormatInt(int64(t), 10)
+		}
+		return fmtFloat(t)
+	case float64:
+		if isFloatInt(t) {
+			return strconv.FormatInt(int64(t), 10)
+		}
+		return fmtFloat(t)
+	case string:
+		if strings.Contains(t, "\n") {
+			return fmt.Sprintf("%q", t)
+		}
+
+		if t == "" {
+			return `""`
+		}
+
+		return t
+	}
+
+	return stringFromAny(fmt.Sprintf("%v", v))
+}
+
+// isFloatInt reports whether a float is an integer number
+// with no fractional part.
+func isFloatInt[F float32 | float64](f F) bool {
+	switch t := any(f).(type) {
+	case float32:
+		return t == float32(int32(f))
+	case float64:
+		return t == float64(int64(f))
+	}
+	return false
+}
+
+func fmtFloat[F float32 | float64](f F) string {
+	s := fmt.Sprintf("%f", f)
+	s = strings.TrimRight(s, "0")
+	s = strings.TrimRight(s, ".")
+	return s
+}
+
+func intFromAny(v any) (int, bool) {
+	if v == nil {
+		return 0, false
+	}
+
+	switch v := v.(type) {
+	case int:
+		return v, true
+	case int32:
+		return int(v), true
+	case int64:
+		if int64(int(v)) == v {
+			return int(v), true
+		}
+	case float32:
+		return int(v), true
+	case float64:
+		if float64(int(v)) == v {
+			return int(v), true
+		}
+	case string:
+		if i, err := strconv.Atoi(v); err == nil {
+			return i, true
+		}
+	}
+	return 0, false
+}

--- a/validator.go
+++ b/validator.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/calyptia/go-fluentbit-config/property"
+	"github.com/calyptia/go-fluentbit-config/v2/property"
 )
 
 var ErrMissingName = errors.New("missing name property")
@@ -23,16 +23,13 @@ func (c Config) Validate() error {
 // has a property named "pid" that is of integer type,
 // it must be a valid integer.
 func (c Config) ValidateWithSchema(schema Schema) error {
-	validate := func(kind SectionKind, byNames []ByName) error {
-		for _, byName := range byNames {
-			for _, props := range byName {
-				if err := ValidateSectionWithSchema(kind, props, schema); err != nil {
-					return err
-				}
+	validate := func(kind SectionKind, plugins Plugins) error {
+		for _, plugin := range plugins {
+			if err := ValidateSectionWithSchema(kind, plugin.Properties, schema); err != nil {
+				return err
 			}
 		}
 
-		// valid by default
 		return nil
 	}
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -1,12 +1,10 @@
-package fluentbitconfig_test
+package fluentbitconfig
 
 import (
 	_ "embed"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
-
-	fluentbitconfig "github.com/calyptia/go-fluentbit-config"
 )
 
 func TestConfig_Validate(t *testing.T) {
@@ -293,7 +291,7 @@ func TestConfig_Validate(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			var classicConf fluentbitconfig.Config
+			var classicConf Config
 			err := classicConf.UnmarshalClassic([]byte(tc.ini))
 			assert.NoError(t, err)
 


### PR DESCRIPTION
Removing the plugin properties single item array, and instead place the properties directly, aka:

From:

```yaml
pipeline:
  inputs:
    - dummy:
      name: dummy
```

To:

```yaml
pipeline:
  inputs:
    - name: dummy
```

This is to align with fluent-bit new YAML format.

Also improved how IDs work by placing them directly on the struct instead of computing them each time.

Also added service port detection. This is so we can create the service ports on kubernetes. This is something we currently do on Cloud but it's not complete and some plugins don't generate a service port there, but now it should be up to date ;=)

I upgraded the go module name and added `/v2` since this is a breaking change. We should do a data migration in Cloud from the old config format to this new one.