### PR TITLE
handle v1 yaml/json format

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -88,6 +88,8 @@ func (p *Plugin) UnmarshalJSON(data []byte) error {
 	}
 
 	p.Name = Name(p.Properties)
+	p.handleV1()
+
 	return nil
 }
 
@@ -98,7 +100,30 @@ func (p *Plugin) UnmarshalYAML(node *yaml.Node) error {
 	}
 
 	p.Name = Name(p.Properties)
+	p.handleV1()
+
 	return nil
+}
+
+// handleV1 adds support for old v1 format.
+func (p *Plugin) handleV1() {
+	if len(p.Properties) != 1 || p.Name != "" {
+		return
+	}
+
+	for _, prop := range p.Properties {
+		// TODO: keep order of properties.
+		props, ok := prop.Value.(map[string]any)
+		if !ok {
+			break
+		}
+
+		p.Properties = property.Properties{}
+		for k, v := range props {
+			p.Properties.Add(k, v)
+		}
+		p.Name = Name(p.Properties)
+	}
 }
 
 func (p Plugin) Equal(target Plugin) bool {

--- a/testdata/full-v1.json
+++ b/testdata/full-v1.json
@@ -1,0 +1,70 @@
+{
+    "env": {
+        "FOO": "bar",
+        "BAZ": "qux"
+    },
+    "service": {
+        "flush": 1,
+        "daemon": "on",
+        "log_level": "error",
+        "http_server": "on"
+    },
+    "customs": [
+        {
+            "calyptia": {
+                "name": "calyptia",
+                "api_key": "secret"
+            }
+        }
+    ],
+    "pipeline": {
+        "inputs": [
+            {
+                "syslog": {
+                    "name": "syslog",
+                    "listen": "0.0.0.0",
+                    "port": 5140
+                }
+            },
+            {
+                "tail": {
+                    "name": "tail",
+                    "exit_on_eof": false
+                }
+            },
+            {
+                "dummy": {
+                    "name": "dummy",
+                    "dummy": "{\"message\": \"hello from fluent-bit\"}"
+                }
+            }
+        ],
+        "filters": [
+            {
+                "throttle": {
+                    "name": "throttle",
+                    "match": "syslog",
+                    "rate": 3.14
+                }
+            },
+            {
+                "record_modifier": {
+                    "name": "record_modifier",
+                    "match": "dummy",
+                    "record": [
+                        "key1 value1",
+                        "key2 value2"
+                    ]
+                }
+            }
+        ],
+        "outputs": [
+            {
+                "stdout": {
+                    "name": "stdout",
+                    "match": "*"
+                }
+            }
+        ]
+    }
+}

--- a/testdata/full-v1.yaml
+++ b/testdata/full-v1.yaml
@@ -1,0 +1,39 @@
+env:
+    FOO: bar
+    BAZ: qux
+service:
+    flush: 1
+    daemon: "on"
+    log_level: error
+    http_server: "on"
+customs:
+    - calyptia:
+        name: calyptia
+        api_key: secret
+pipeline:
+    inputs:
+        - syslog:
+            name: syslog
+            listen: 0.0.0.0
+            port: 5140
+        - tail:
+            name: tail
+            exit_on_eof: false
+        - dummy:
+            name: dummy
+            dummy: '{"message": "hello from fluent-bit"}'
+    filters:
+        - throttle:
+            name: throttle
+            match: syslog
+            rate: 3.14
+        - record_modifier:
+            name: record_modifier
+            match: dummy
+            record:
+              - key1 value1
+              - key2 value2
+    outputs:
+        - stdout:
+            name: stdout
+            match: '*'


### PR DESCRIPTION
Adding a special handling for old v1 yaml/json format.

Notice that this does not keep the order of properties of the old v1 format, hence the tests are disabled for this case, but I confirmed it works, it just does not warranty the properties order.

I made this PR just as a lifeguard in the meanwhile we do the migration from v1 to v2.