### PR TITLE
fix: go.mod has post -v0 path.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/calyptia/go-fluentbit-config/v2
+module github.com/calyptia/go-fluentbit-config
 
 go 1.20
 


### PR DESCRIPTION
Either we release a v2.x version or we remove this from the module path. Try as I might it will not budge.

references:
- https://stackoverflow.com/questions/52050146/go-build-keeps-complaining-that-go-mod-has-post-v0-module-path.
- https://go.dev/doc/modules/version-numbers
- https://go.dev/doc/modules/release-workflow