### PR TITLE
skip unknown plugin port

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,6 +1,11 @@
 package fluentbitconfig
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrMissingName = errors.New("missing name property")
 
 // LinedError with information about the line number
 // where the error was found while parsing.
@@ -19,4 +24,17 @@ func NewLinedError(msg string, line uint) *LinedError {
 
 func WrapLinedError(err error, line uint) *LinedError {
 	return &LinedError{Msg: err.Error(), Line: line}
+}
+
+type UnknownPluginError struct {
+	Kind SectionKind
+	Name string
+}
+
+func NewUnknownPluginError(kind SectionKind, name string) *UnknownPluginError {
+	return &UnknownPluginError{Kind: kind, Name: name}
+}
+
+func (e *UnknownPluginError) Error() string {
+	return fmt.Sprintf("%s: unknown plugin %q", e.Kind, e.Name)
 }

--- a/schema.go
+++ b/schema.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-//go:embed schemas/1.9.json
+//go:embed schemas/23.4.3.json
 var rawSchema []byte
 
 var DefaultSchema = func() Schema {

--- a/schemas/23.4.3.json
+++ b/schemas/23.4.3.json
@@ -1,6 +1,6 @@
 {
     "fluent-bit": {
-        "version": "1.9",
+        "version": "23.4.3",
         "schema_version": "1",
         "os": "linux"
     },
@@ -56,6 +56,18 @@
                     {
                         "name": "machine_id",
                         "description": "Custom machine_id to be used when registering agent",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "fleet_id",
+                        "description": "Fleet id to be used when registering agent in a fleet",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "pipeline_id",
+                        "description": "Pipeline ID for reporting to calyptia cloud.",
                         "default": null,
                         "type": "string"
                     }
@@ -398,6 +410,60 @@
                         "type": "integer"
                     },
                     {
+                        "name": "tls",
+                        "description": "Enable or disable TLS/SSL support",
+                        "default": "off",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.verify",
+                        "description": "Force certificate validation",
+                        "default": "on",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.debug",
+                        "description": "Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                        "default": "1",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "tls.ca_file",
+                        "description": "Absolute path to CA certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.ca_path",
+                        "description": "Absolute path to scan for certificate files",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.crt_file",
+                        "description": "Absolute path to Certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_file",
+                        "description": "Absolute path to private Key file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_passwd",
+                        "description": "Optional password for tls.key_file file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.vhost",
+                        "description": "Hostname to be used for TLS SNI extension",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
                         "name": "unix_path",
                         "description": "Define Docker unix socket path to read events",
                         "default": "/var/run/docker.sock",
@@ -449,6 +515,96 @@
                         "type": "time"
                     },
                     {
+                        "name": "collector.cpu.scrape_interval",
+                        "description": "scrape interval to collect cpu metrics from the node.",
+                        "default": "0",
+                        "type": "time"
+                    },
+                    {
+                        "name": "collector.cpufreq.scrape_interval",
+                        "description": "scrape interval to collect cpufreq metrics from the node.",
+                        "default": "0",
+                        "type": "time"
+                    },
+                    {
+                        "name": "collector.meminfo.scrape_interval",
+                        "description": "scrape interval to collect meminfo metrics from the node.",
+                        "default": "0",
+                        "type": "time"
+                    },
+                    {
+                        "name": "collector.diskstats.scrape_interval",
+                        "description": "scrape interval to collect diskstats metrics from the node.",
+                        "default": "0",
+                        "type": "time"
+                    },
+                    {
+                        "name": "collector.filesystem.scrape_interval",
+                        "description": "scrape interval to collect filesystem metrics from the node.",
+                        "default": "0",
+                        "type": "time"
+                    },
+                    {
+                        "name": "collector.uname.scrape_interval",
+                        "description": "scrape interval to collect uname metrics from the node.",
+                        "default": "0",
+                        "type": "time"
+                    },
+                    {
+                        "name": "collector.stat.scrape_interval",
+                        "description": "scrape interval to collect stat metrics from the node.",
+                        "default": "0",
+                        "type": "time"
+                    },
+                    {
+                        "name": "collector.time.scrape_interval",
+                        "description": "scrape interval to collect time metrics from the node.",
+                        "default": "0",
+                        "type": "time"
+                    },
+                    {
+                        "name": "collector.loadavg.scrape_interval",
+                        "description": "scrape interval to collect loadavg metrics from the node.",
+                        "default": "0",
+                        "type": "time"
+                    },
+                    {
+                        "name": "collector.vmstat.scrape_interval",
+                        "description": "scrape interval to collect vmstat metrics from the node.",
+                        "default": "0",
+                        "type": "time"
+                    },
+                    {
+                        "name": "collector.netdev.scrape_interval",
+                        "description": "scrape interval to collect netdev metrics from the node.",
+                        "default": "0",
+                        "type": "time"
+                    },
+                    {
+                        "name": "collector.filefd.scrape_interval",
+                        "description": "scrape interval to collect filefd metrics from the node.",
+                        "default": "0",
+                        "type": "time"
+                    },
+                    {
+                        "name": "collector.textfile.scrape_interval",
+                        "description": "scrape interval to collect textfile metrics from the node.",
+                        "default": "0",
+                        "type": "time"
+                    },
+                    {
+                        "name": "metrics",
+                        "description": "Comma separated list of keys to enable metrics.",
+                        "default": "cpu,cpufreq,meminfo,diskstats,filesystem,uname,stat,time,loadavg,vmstat,netdev,filefd",
+                        "type": "multiple comma delimited strings"
+                    },
+                    {
+                        "name": "collector.textfile.path",
+                        "description": "Specify file path or directory to collect textfile metrics from the node.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
                         "name": "path.procfs",
                         "description": "procfs mount point",
                         "default": "/proc",
@@ -459,6 +615,90 @@
                         "description": "sysfs mount point",
                         "default": "/sys",
                         "type": "string"
+                    }
+                ]
+            }
+        },
+        {
+            "type": "input",
+            "name": "podman_metrics",
+            "description": "Podman metrics",
+            "properties": {
+                "options": [
+                    {
+                        "name": "scrape_interval",
+                        "description": "Scrape interval to collect the metrics of podman containers(defaults to 30s)",
+                        "default": "30",
+                        "type": "time"
+                    },
+                    {
+                        "name": "scrape_on_start",
+                        "description": "Scrape metrics upon start, useful to avoid waiting for 'scrape_interval' for the first round of metrics.",
+                        "default": "false",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "path.config",
+                        "description": "Path to podman config file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "path.sysfs",
+                        "description": "Path to sysfs subsystem directory",
+                        "default": "/sys/fs/cgroup",
+                        "type": "string"
+                    },
+                    {
+                        "name": "path.procfs",
+                        "description": "Path to proc subsystem directory",
+                        "default": "/proc",
+                        "type": "string"
+                    }
+                ]
+            }
+        },
+        {
+            "type": "input",
+            "name": "kafka",
+            "description": "Kafka consumer input plugin",
+            "properties": {
+                "options": [
+                    {
+                        "name": "poll_ms",
+                        "description": "Interval in milliseconds to check for new messages.",
+                        "default": "500",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "topics",
+                        "description": "Set the kafka topics, delimited by commas.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "brokers",
+                        "description": "Set the kafka brokers, delimited by commas.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "client_id",
+                        "description": "Set the kafka client_id.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "group_id",
+                        "description": "Set the kafka group_id.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "rdkafka.",
+                        "description": "Set the librdkafka options",
+                        "default": null,
+                        "type": "prefixed string"
                     }
                 ]
             }
@@ -503,10 +743,70 @@
                         "type": "integer"
                     },
                     {
+                        "name": "tls",
+                        "description": "Enable or disable TLS/SSL support",
+                        "default": "off",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.verify",
+                        "description": "Force certificate validation",
+                        "default": "on",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.debug",
+                        "description": "Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                        "default": "1",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "tls.ca_file",
+                        "description": "Absolute path to CA certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.ca_path",
+                        "description": "Absolute path to scan for certificate files",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.crt_file",
+                        "description": "Absolute path to Certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_file",
+                        "description": "Absolute path to private Key file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_passwd",
+                        "description": "Optional password for tls.key_file file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.vhost",
+                        "description": "Hostname to be used for TLS SNI extension",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
                         "name": "scrape_interval",
                         "description": "Scraping interval.",
                         "default": "10s",
                         "type": "time"
+                    },
+                    {
+                        "name": "buffer_max_size",
+                        "description": "",
+                        "default": "10M",
+                        "type": "size"
                     },
                     {
                         "name": "metrics_path",
@@ -558,6 +858,18 @@
                         "description": "",
                         "default": "2s",
                         "type": "time"
+                    },
+                    {
+                        "name": "progress_check_interval",
+                        "description": "",
+                        "default": "2s",
+                        "type": "time"
+                    },
+                    {
+                        "name": "progress_check_interval_nsec",
+                        "description": "",
+                        "default": "0",
+                        "type": "integer"
                     },
                     {
                         "name": "rotate_wait",
@@ -737,8 +1049,20 @@
                         "type": "string"
                     },
                     {
+                        "name": "metadata",
+                        "description": "set the sample metadata to be generated. It should be a JSON object.",
+                        "default": "{}",
+                        "type": "string"
+                    },
+                    {
                         "name": "rate",
                         "description": "set a number of events per second.",
+                        "default": "1",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "copies",
+                        "description": "set the number of copies to generate per collectd.",
                         "default": "1",
                         "type": "integer"
                     },
@@ -759,27 +1083,6 @@
                         "description": "used a fixed timestamp, allows the message to pre-generated once.",
                         "default": "off",
                         "type": "boolean"
-                    }
-                ]
-            }
-        },
-        {
-            "type": "input",
-            "name": "dummy_thread",
-            "description": "Generate dummy data in a separate thread",
-            "properties": {
-                "options": [
-                    {
-                        "name": "message",
-                        "description": "Define dummy message",
-                        "default": "thready dummy",
-                        "type": "string"
-                    },
-                    {
-                        "name": "samples",
-                        "description": "Define the number of samples to send",
-                        "default": "1000000",
-                        "type": "integer"
                     }
                 ]
             }
@@ -860,6 +1163,60 @@
                         "type": "integer"
                     },
                     {
+                        "name": "tls",
+                        "description": "Enable or disable TLS/SSL support",
+                        "default": "off",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.verify",
+                        "description": "Force certificate validation",
+                        "default": "on",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.debug",
+                        "description": "Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                        "default": "1",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "tls.ca_file",
+                        "description": "Absolute path to CA certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.ca_path",
+                        "description": "Absolute path to scan for certificate files",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.crt_file",
+                        "description": "Absolute path to Certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_file",
+                        "description": "Absolute path to private Key file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_passwd",
+                        "description": "Optional password for tls.key_file file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.vhost",
+                        "description": "Hostname to be used for TLS SNI extension",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
                         "name": "alert",
                         "description": "Only generate records when the port is down",
                         "default": "false",
@@ -911,6 +1268,60 @@
                         "type": "integer"
                     },
                     {
+                        "name": "tls",
+                        "description": "Enable or disable TLS/SSL support",
+                        "default": "off",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.verify",
+                        "description": "Force certificate validation",
+                        "default": "on",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.debug",
+                        "description": "Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                        "default": "1",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "tls.ca_file",
+                        "description": "Absolute path to CA certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.ca_path",
+                        "description": "Absolute path to scan for certificate files",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.crt_file",
+                        "description": "Absolute path to Certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_file",
+                        "description": "Absolute path to private Key file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_passwd",
+                        "description": "Optional password for tls.key_file file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.vhost",
+                        "description": "Hostname to be used for TLS SNI extension",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
                         "name": "buffer_max_size",
                         "description": "",
                         "default": "4M",
@@ -921,6 +1332,12 @@
                         "description": "",
                         "default": "512K",
                         "type": "size"
+                    },
+                    {
+                        "name": "success_header",
+                        "description": "Add an HTTP header key/value pair on success. Multiple headers can be set",
+                        "default": null,
+                        "type": "space delimited strings (minimum 1)"
                     },
                     {
                         "name": "tag_key",
@@ -979,6 +1396,60 @@
                         "type": "integer"
                     },
                     {
+                        "name": "tls",
+                        "description": "Enable or disable TLS/SSL support",
+                        "default": "off",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.verify",
+                        "description": "Force certificate validation",
+                        "default": "on",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.debug",
+                        "description": "Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                        "default": "1",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "tls.ca_file",
+                        "description": "Absolute path to CA certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.ca_path",
+                        "description": "Absolute path to scan for certificate files",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.crt_file",
+                        "description": "Absolute path to Certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_file",
+                        "description": "Absolute path to private Key file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_passwd",
+                        "description": "Optional password for tls.key_file file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.vhost",
+                        "description": "Hostname to be used for TLS SNI extension",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
                         "name": "buffer_max_size",
                         "description": "",
                         "default": "4M",
@@ -1001,6 +1472,228 @@
                         "description": "Set successful response code. 200, 201 and 204 are supported.",
                         "default": "201",
                         "type": "integer"
+                    },
+                    {
+                        "name": "raw_traces",
+                        "description": "Forward traces without processing",
+                        "default": "false",
+                        "type": "boolean"
+                    }
+                ]
+            }
+        },
+        {
+            "type": "input",
+            "name": "elasticsearch",
+            "description": "HTTP Endpoints for Elasticsearch (Bulk API)",
+            "properties": {
+                "options": [
+                    {
+                        "name": "host",
+                        "description": "Listen Address",
+                        "default": "0.0.0.0",
+                        "type": "string"
+                    },
+                    {
+                        "name": "port",
+                        "description": "Listen Port",
+                        "default": "0",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "tls",
+                        "description": "Enable or disable TLS/SSL support",
+                        "default": "off",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.verify",
+                        "description": "Force certificate validation",
+                        "default": "on",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.debug",
+                        "description": "Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                        "default": "1",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "tls.ca_file",
+                        "description": "Absolute path to CA certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.ca_path",
+                        "description": "Absolute path to scan for certificate files",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.crt_file",
+                        "description": "Absolute path to Certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_file",
+                        "description": "Absolute path to private Key file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_passwd",
+                        "description": "Optional password for tls.key_file file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.vhost",
+                        "description": "Hostname to be used for TLS SNI extension",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "buffer_max_size",
+                        "description": "Set the maximum size of buffer",
+                        "default": "4M",
+                        "type": "size"
+                    },
+                    {
+                        "name": "buffer_chunk_size",
+                        "description": "Set the buffer chunk size",
+                        "default": "512K",
+                        "type": "size"
+                    },
+                    {
+                        "name": "tag_key",
+                        "description": "Specify a key name for extracting as a tag",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "meta_key",
+                        "description": "Specify a key name for meta information",
+                        "default": "@meta",
+                        "type": "string"
+                    },
+                    {
+                        "name": "hostname",
+                        "description": "Specify hostname or FQDN. This parameter is effective for sniffering node information.",
+                        "default": "localhost",
+                        "type": "string"
+                    }
+                ]
+            }
+        },
+        {
+            "type": "input",
+            "name": "calyptia_fleet",
+            "description": "Calyptia Fleet Input",
+            "properties": {
+                "options": [
+                    {
+                        "name": "host",
+                        "description": "Listen Address",
+                        "default": "0.0.0.0",
+                        "type": "string"
+                    },
+                    {
+                        "name": "port",
+                        "description": "Listen Port",
+                        "default": "0",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "tls",
+                        "description": "Enable or disable TLS/SSL support",
+                        "default": "off",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.verify",
+                        "description": "Force certificate validation",
+                        "default": "on",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.debug",
+                        "description": "Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                        "default": "1",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "tls.ca_file",
+                        "description": "Absolute path to CA certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.ca_path",
+                        "description": "Absolute path to scan for certificate files",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.crt_file",
+                        "description": "Absolute path to Certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_file",
+                        "description": "Absolute path to private Key file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_passwd",
+                        "description": "Optional password for tls.key_file file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.vhost",
+                        "description": "Hostname to be used for TLS SNI extension",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "api_key",
+                        "description": "Calyptia Cloud API Key.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "config_dir",
+                        "description": "Base path for the configuration directory.",
+                        "default": "/tmp/calyptia-fleet",
+                        "type": "string"
+                    },
+                    {
+                        "name": "fleet_id",
+                        "description": "Calyptia Fleet ID.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "event_fd",
+                        "description": "Used internally to set the event fd.",
+                        "default": "-1",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "interval_sec",
+                        "description": "Set the collector interval",
+                        "default": "3",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "interval_nsec",
+                        "description": "Set the collector interval (nanoseconds)",
+                        "default": "0",
+                        "type": "integer"
                     }
                 ]
             }
@@ -1011,6 +1704,33 @@
             "description": "Event tests for input plugins",
             "properties": {
                 "options": []
+            }
+        },
+        {
+            "type": "input",
+            "name": "event_type",
+            "description": "Event tests for input plugins",
+            "properties": {
+                "options": [
+                    {
+                        "name": "type",
+                        "description": "Set the type of event to deliver, optionsa are: logs, metrics or traces",
+                        "default": "logs",
+                        "type": "string"
+                    },
+                    {
+                        "name": "interval_sec",
+                        "description": "Set the interval seconds between events generation",
+                        "default": "2",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "interval_nsec",
+                        "description": "Set the nanoseconds interval (sub seconds)",
+                        "default": "0",
+                        "type": "integer"
+                    }
+                ]
             }
         },
         {
@@ -1030,6 +1750,60 @@
                         "description": "Listen Port",
                         "default": "0",
                         "type": "integer"
+                    },
+                    {
+                        "name": "tls",
+                        "description": "Enable or disable TLS/SSL support",
+                        "default": "off",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.verify",
+                        "description": "Force certificate validation",
+                        "default": "on",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.debug",
+                        "description": "Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                        "default": "1",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "tls.ca_file",
+                        "description": "Absolute path to CA certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.ca_path",
+                        "description": "Absolute path to scan for certificate files",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.crt_file",
+                        "description": "Absolute path to Certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_file",
+                        "description": "Absolute path to private Key file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_passwd",
+                        "description": "Optional password for tls.key_file file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.vhost",
+                        "description": "Hostname to be used for TLS SNI extension",
+                        "default": null,
+                        "type": "string"
                     },
                     {
                         "name": "status_url",
@@ -1125,6 +1899,60 @@
                         "type": "integer"
                     },
                     {
+                        "name": "tls",
+                        "description": "Enable or disable TLS/SSL support",
+                        "default": "off",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.verify",
+                        "description": "Force certificate validation",
+                        "default": "on",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.debug",
+                        "description": "Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                        "default": "1",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "tls.ca_file",
+                        "description": "Absolute path to CA certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.ca_path",
+                        "description": "Absolute path to scan for certificate files",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.crt_file",
+                        "description": "Absolute path to Certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_file",
+                        "description": "Absolute path to private Key file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_passwd",
+                        "description": "Optional password for tls.key_file file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.vhost",
+                        "description": "Hostname to be used for TLS SNI extension",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
                         "name": "mode",
                         "description": "Set the socket mode: unix_tcp, unix_udp, tcp or udp",
                         "default": null,
@@ -1157,6 +1985,18 @@
                     {
                         "name": "parser",
                         "description": "Set the parser",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "receive_buffer_size",
+                        "description": "Set the socket receiving buffer size",
+                        "default": null,
+                        "type": "size"
+                    },
+                    {
+                        "name": "raw_message_key",
+                        "description": "Key where the raw message will be preserved",
                         "default": null,
                         "type": "string"
                     }
@@ -1323,6 +2163,60 @@
                         "type": "integer"
                     },
                     {
+                        "name": "tls",
+                        "description": "Enable or disable TLS/SSL support",
+                        "default": "off",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.verify",
+                        "description": "Force certificate validation",
+                        "default": "on",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.debug",
+                        "description": "Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                        "default": "1",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "tls.ca_file",
+                        "description": "Absolute path to CA certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.ca_path",
+                        "description": "Absolute path to scan for certificate files",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.crt_file",
+                        "description": "Absolute path to Certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_file",
+                        "description": "Absolute path to private Key file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_passwd",
+                        "description": "Optional password for tls.key_file file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.vhost",
+                        "description": "Hostname to be used for TLS SNI extension",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
                         "name": "format",
                         "description": "Set the format: json or none",
                         "default": null,
@@ -1366,6 +2260,60 @@
                         "description": "Listen Port",
                         "default": "0",
                         "type": "integer"
+                    },
+                    {
+                        "name": "tls",
+                        "description": "Enable or disable TLS/SSL support",
+                        "default": "off",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.verify",
+                        "description": "Force certificate validation",
+                        "default": "on",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.debug",
+                        "description": "Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                        "default": "1",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "tls.ca_file",
+                        "description": "Absolute path to CA certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.ca_path",
+                        "description": "Absolute path to scan for certificate files",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.crt_file",
+                        "description": "Absolute path to Certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_file",
+                        "description": "Absolute path to private Key file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_passwd",
+                        "description": "Optional password for tls.key_file file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.vhost",
+                        "description": "Hostname to be used for TLS SNI extension",
+                        "default": null,
+                        "type": "string"
                     }
                 ]
             }
@@ -1393,6 +2341,60 @@
                         "description": "Listen Port",
                         "default": "0",
                         "type": "integer"
+                    },
+                    {
+                        "name": "tls",
+                        "description": "Enable or disable TLS/SSL support",
+                        "default": "off",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.verify",
+                        "description": "Force certificate validation",
+                        "default": "on",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tls.debug",
+                        "description": "Set TLS debug verbosity level. It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose",
+                        "default": "1",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "tls.ca_file",
+                        "description": "Absolute path to CA certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.ca_path",
+                        "description": "Absolute path to scan for certificate files",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.crt_file",
+                        "description": "Absolute path to Certificate file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_file",
+                        "description": "Absolute path to private Key file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.key_passwd",
+                        "description": "Optional password for tls.key_file file",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tls.vhost",
+                        "description": "Hostname to be used for TLS SNI extension",
+                        "default": null,
+                        "type": "string"
                     },
                     {
                         "name": "tag_prefix",
@@ -1536,6 +2538,24 @@
                         "description": "Enable EC2 instance hostname",
                         "default": "false",
                         "type": "boolean"
+                    },
+                    {
+                        "name": "tags_enabled",
+                        "description": "Enable EC2 instance tags, injects all tags if tags_include and tags_exclude are empty",
+                        "default": "false",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tags_include",
+                        "description": "Defines list of specific EC2 tag keys to inject into the logs; tag keys must be separated by \",\" character; tags which are not present in this list will be ignored; e.g.: \"Name,tag1,tag2\"",
+                        "default": "",
+                        "type": "string"
+                    },
+                    {
+                        "name": "tags_exclude",
+                        "description": "Defines list of specific EC2 tag keys not to inject into the logs; tag keys must be separated by \",\" character; if both tags_include and tags_exclude are specified, configuration is invalid and plugin fails",
+                        "default": "",
+                        "type": "string"
                     }
                 ]
             }
@@ -1587,6 +2607,57 @@
         },
         {
             "type": "filter",
+            "name": "ecs",
+            "description": "Add AWS ECS Metadata",
+            "properties": {
+                "options": [
+                    {
+                        "name": "add",
+                        "description": "Add a metadata key/value pair with the given key and given value from the given template. Format is `Add KEY TEMPLATE`.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "ecs_tag_prefix",
+                        "description": "This filter must obtain the 12 character container short ID to query for ECS Task metadata. The filter removes the prefx from the tag and then assumes the next 12 characters are the short container ID. If the container short ID, is not found in the tag, the filter can/must fallback to only attaching cluster metadata (cluster name, container instance ID/ARN, and ECS Agent version).",
+                        "default": "",
+                        "type": "string"
+                    },
+                    {
+                        "name": "cluster_metadata_only",
+                        "description": "Only attempt to attach the cluster related metadata to logs (cluster name, container instance ID/ARN, and ECS Agent version). With this option off, if this filter can not obtain the task metadata for a log, it will output errors. Use this option if you have logs that are not part of an ECS task (ex: Docker Daemon logs).",
+                        "default": "false",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "ecs_meta_cache_ttl",
+                        "description": "Configurable TTL for cached ECS Task Metadata. Default 3600s (1 hour)For example, set this value to 600 or 600s or 10m and cache entries which have been created more than 10 minutes will be evicted.Cache eviction is needed to purge task metadata for tasks that have been stopped.",
+                        "default": "3600",
+                        "type": "time"
+                    },
+                    {
+                        "name": "ecs_meta_host",
+                        "description": "The host name at which the ECS Agent Introspection endpoint is reachable. Defaults to 127.0.0.1",
+                        "default": "127.0.0.1",
+                        "type": "string"
+                    },
+                    {
+                        "name": "ecs_meta_port",
+                        "description": "The port at which the ECS Agent Introspection endpoint is reachable. Defaults to 51678",
+                        "default": "51678",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "agent_endpoint_retries",
+                        "description": "Number of retries for failed metadata requests to ECS Agent Introspection endpoint. The most common cause of failed metadata requests is that the container the metadata request was made for is not part of an ECS Task. Check if you have non-task containers and docker dual logging enabled.",
+                        "default": "2",
+                        "type": "integer"
+                    }
+                ]
+            }
+        },
+        {
+            "type": "filter",
             "name": "record_modifier",
             "description": "modify record",
             "properties": {
@@ -1612,6 +2683,12 @@
                     {
                         "name": "whitelist_key",
                         "description": "(Alias of allowlist_key)",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "uuid_key",
+                        "description": "If set, the plugin generates uuid per record.",
                         "default": null,
                         "type": "string"
                     }
@@ -1922,6 +2999,18 @@
                         "type": "string"
                     },
                     {
+                        "name": "Move_To_Start",
+                        "description": "Move key/value pairs with keys matching KEY to the start of the message",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "Move_To_End",
+                        "description": "Move key/value pairs with keys matching KEY to the end of the message",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
                         "name": "Rename",
                         "description": "Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists AND RENAMED_KEY does not exist",
                         "default": null,
@@ -2169,6 +3258,12 @@
                         "description": "Exclude records in which the content of KEY matches the regular expression.",
                         "default": null,
                         "type": "string"
+                    },
+                    {
+                        "name": "logical_op",
+                        "description": "Specify whether to use logical conjuciton or disjunction. legacy, AND and OR are allowed.",
+                        "default": "legacy",
+                        "type": "string"
                     }
                 ]
             }
@@ -2202,6 +3297,75 @@
                         "description": "set a memory buffer limit to restrict memory usage of emitter",
                         "default": "10M",
                         "type": "size"
+                    }
+                ]
+            }
+        },
+        {
+            "type": "filter",
+            "name": "log_to_metrics",
+            "description": "generate log derived metrics",
+            "properties": {
+                "options": [
+                    {
+                        "name": "regex",
+                        "description": "Optional filter for records in which the content of KEY matches the regular expression.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "exclude",
+                        "description": "Optional filter for records in which the content of KEY does not matches the regular expression.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "metric_mode",
+                        "description": "Mode selector. Values counter, gauge, or histogram. Summary is not supported",
+                        "default": "counter",
+                        "type": "string"
+                    },
+                    {
+                        "name": "value_field",
+                        "description": "Numeric field to use for gauge or histogram",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "metric_name",
+                        "description": "Name of metric",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "metric_description",
+                        "description": "Help text for metric",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "kubernetes_mode",
+                        "description": "Enable kubernetes log metric fields",
+                        "default": "false",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "label_field",
+                        "description": "Specify message field that should be included in the metric",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "bucket",
+                        "description": "Specify bucket for histogram metric",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "tag",
+                        "description": "Metric Tag",
+                        "default": null,
+                        "type": "string"
                     }
                 ]
             }
@@ -3652,6 +4816,18 @@
                         "type": "string"
                     },
                     {
+                        "name": "aws_service_name",
+                        "description": "AWS Service Name",
+                        "default": "es",
+                        "type": "string"
+                    },
+                    {
+                        "name": "aws_profile",
+                        "description": "AWS Profile name. AWS Profiles can be configured with AWS CLI and are usually stored in $HOME/.aws/ directory.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
                         "name": "logstash_format",
                         "description": "Enable Logstash format compatibility",
                         "default": "false",
@@ -3661,6 +4837,12 @@
                         "name": "logstash_prefix",
                         "description": "When Logstash_Format is enabled, the Index name is composed using a prefix and the date, e.g: If Logstash_Prefix is equals to 'mydata' your index will become 'mydata-YYYY.MM.DD'. The last string appended belongs to the date when the data is being generated",
                         "default": "logstash",
+                        "type": "string"
+                    },
+                    {
+                        "name": "logstash_prefix_separator",
+                        "description": "Set a separator between logstash_prefix and date.",
+                        "default": "-",
                         "type": "string"
                     },
                     {
@@ -4037,6 +5219,12 @@
                         "type": "boolean"
                     },
                     {
+                        "name": "retain_metadata_in_forward_mode",
+                        "description": "Retain metadata when operating in forward mode",
+                        "default": "false",
+                        "type": "boolean"
+                    },
+                    {
                         "name": "shared_key",
                         "description": "Shared key for authentication",
                         "default": null,
@@ -4101,6 +5289,12 @@
                         "description": "Compression mode",
                         "default": null,
                         "type": "string"
+                    },
+                    {
+                        "name": "fluentd_compat",
+                        "description": "Send cmetrics and ctreaces with Fluentd compatible format",
+                        "default": "false",
+                        "type": "boolean"
                     }
                 ],
                 "networking": [
@@ -4358,6 +5552,12 @@
                     {
                         "name": "aws_external_id",
                         "description": "Specify an external ID for the STS API, can be used with the `aws_role_arn` parameter if your role requires an external ID.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "aws_profile",
+                        "description": "AWS Profile name. AWS Profiles can be configured with AWS CLI and are usuallystored in $HOME/.aws/ directory.",
                         "default": null,
                         "type": "string"
                     },
@@ -5139,6 +6339,12 @@
                         "type": "string"
                     },
                     {
+                        "name": "label_map_path",
+                        "description": "A label map file path",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
                         "name": "http_user",
                         "description": "Set HTTP auth user",
                         "default": null,
@@ -5148,6 +6354,12 @@
                         "name": "http_passwd",
                         "description": "Set HTTP auth password",
                         "default": "",
+                        "type": "string"
+                    },
+                    {
+                        "name": "bearer_token",
+                        "description": "Set bearer token auth",
+                        "default": null,
                         "type": "string"
                     }
                 ],
@@ -5267,6 +6479,135 @@
                         "description": "Hostname to be used for TLS SNI extension",
                         "default": null,
                         "type": "string"
+                    }
+                ]
+            }
+        },
+        {
+            "type": "output",
+            "name": "kafka",
+            "description": "Kafka",
+            "properties": {
+                "options": [
+                    {
+                        "name": "topic_key",
+                        "description": "Which record to use as the kafka topic.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "dynamic_topic",
+                        "description": "Activate dynamic topics.",
+                        "default": "false",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "format",
+                        "description": "Set the record output format.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "message_key",
+                        "description": "Which record key to use as the message data.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "message_key_field",
+                        "description": "Which record key field to use as the message data.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "timestamp_key",
+                        "description": "Set the key for the the timestamp.",
+                        "default": "@timestamp",
+                        "type": "string"
+                    },
+                    {
+                        "name": "timestamp_format",
+                        "description": "Set the format the timestamp is in.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "queue_full_retries",
+                        "description": "Set the number of local retries to enqueue the data.",
+                        "default": "10",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "gelf_timestamp_key",
+                        "description": "Set the timestamp key for gelf  output.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "gelf_host_key",
+                        "description": "Set the host key for gelf  output.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "gelf_short_message_key",
+                        "description": "Set the short message key for gelf  output.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "gelf_full_message_key",
+                        "description": "Set the full message key for gelf  output.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "gelf_level_key",
+                        "description": "Set the level key for gelf  output.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "schema_str",
+                        "description": "Set AVRO schema.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "schema_id",
+                        "description": "Set AVRO schema ID.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "topics",
+                        "description": "Set the kafka topics, delimited by commas.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "brokers",
+                        "description": "Set the kafka brokers, delimited by commas.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "client_id",
+                        "description": "Set the kafka client_id.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "group_id",
+                        "description": "Set the kafka group_id.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "rdkafka.",
+                        "description": "Set the kafka group_id.",
+                        "default": null,
+                        "type": "prefixed string"
                     }
                 ]
             }
@@ -5906,6 +7247,12 @@
                         "type": "string"
                     },
                     {
+                        "name": "aws_profile",
+                        "description": "AWS Profile name. AWS Profiles can be configured with AWS CLI and are usually stored in $HOME/.aws/ directory.",
+                        "default": "default",
+                        "type": "string"
+                    },
+                    {
                         "name": "aws_sts_endpoint",
                         "description": "Custom endpoint for the AWS STS API, used with the AWS_Role_ARN option",
                         "default": null,
@@ -5924,6 +7271,12 @@
                         "type": "string"
                     },
                     {
+                        "name": "aws_service_name",
+                        "description": "AWS Service Name",
+                        "default": "es",
+                        "type": "string"
+                    },
+                    {
                         "name": "logstash_format",
                         "description": "Enable Logstash format compatibility",
                         "default": "false",
@@ -5933,6 +7286,12 @@
                         "name": "logstash_prefix",
                         "description": "When Logstash_Format is enabled, the Index name is composed using a prefix and the date, e.g: If Logstash_Prefix is equals to 'mydata' your index will become 'mydata-YYYY.MM.DD'. The last string appended belongs to the date when the data is being generated",
                         "default": "logstash",
+                        "type": "string"
+                    },
+                    {
+                        "name": "logstash_prefix_separator",
+                        "description": "Set a separator between logstash_prefix and date.",
+                        "default": "-",
                         "type": "string"
                     },
                     {
@@ -6178,6 +7537,12 @@
                     }
                 ]
             }
+        },
+        {
+            "type": "output",
+            "name": "pgsql",
+            "description": "PostgreSQL",
+            "properties": {}
         },
         {
             "type": "output",
@@ -7231,14 +8596,32 @@
                         "type": "string"
                     },
                     {
+                        "name": "syslog_severity_preset",
+                        "description": "Specify the preset severity number. It must be 0-7.  This configuration is optional.",
+                        "default": "6",
+                        "type": "integer"
+                    },
+                    {
                         "name": "syslog_facility_key",
                         "description": "Specify the name of the key from the original record that contains the Syslog facility number. This configuration is optional.",
                         "default": null,
                         "type": "string"
                     },
                     {
+                        "name": "syslog_facility_preset",
+                        "description": "Specify the preset facility number. It must be 0-23.  This configuration is optional.",
+                        "default": "1",
+                        "type": "integer"
+                    },
+                    {
                         "name": "syslog_hostname_key",
                         "description": "Specify the key name from the original record that contains the hostname that generated the message. This configuration is optional.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "syslog_hostname_preset",
+                        "description": "Specify the preset hostname. This configuration is optional.",
                         "default": null,
                         "type": "string"
                     },
@@ -7249,14 +8632,32 @@
                         "type": "string"
                     },
                     {
+                        "name": "syslog_appname_preset",
+                        "description": "Specify the preset appname. This configuration is optional.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
                         "name": "syslog_procid_key",
                         "description": "Specify the key name from the original record that contains the Process ID that generated the message. This configuration is optional.",
                         "default": null,
                         "type": "string"
                     },
                     {
+                        "name": "syslog_procid_preset",
+                        "description": "Specify the preset procid.  This configuration is optional.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
                         "name": "syslog_msgid_key",
                         "description": "Specify the key name from the original record that contains the Message ID associated to the message. This configuration is optional.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "syslog_msgid_preset",
+                        "description": "Specify the preset msgid. This configuration is optional.",
                         "default": null,
                         "type": "string"
                     },
@@ -7271,6 +8672,12 @@
                         "description": "Specify the key name that contains the message to deliver. Note that if this property is mandatory, otherwise the message will be empty.",
                         "default": null,
                         "type": "string"
+                    },
+                    {
+                        "name": "allow_longer_sd_id",
+                        "description": "If true, Fluent-bit allows SD-ID that is longer than 32 characters. Such long SD-ID violates RFC 5424.",
+                        "default": "false",
+                        "type": "boolean"
                     }
                 ],
                 "networking": [
@@ -7482,6 +8889,12 @@
                         "description": "Specify the name of the date field in output.",
                         "default": "date",
                         "type": "string"
+                    },
+                    {
+                        "name": "raw_message_key",
+                        "description": "use a raw message key for the message.",
+                        "default": null,
+                        "type": "string"
                     }
                 ],
                 "networking": [
@@ -7600,6 +9013,113 @@
                         "description": "Hostname to be used for TLS SNI extension",
                         "default": null,
                         "type": "string"
+                    }
+                ]
+            }
+        },
+        {
+            "type": "output",
+            "name": "udp",
+            "description": "UDP Output",
+            "properties": {
+                "options": [
+                    {
+                        "name": "host",
+                        "description": "Host Address",
+                        "default": "",
+                        "type": "string"
+                    },
+                    {
+                        "name": "port",
+                        "description": "host Port",
+                        "default": "0",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "format",
+                        "description": "Specify the payload format, supported formats: msgpack, json, json_lines or json_stream.",
+                        "default": "json_lines",
+                        "type": "string"
+                    },
+                    {
+                        "name": "json_date_format",
+                        "description": "Specify the format of the date, supported formats: double, iso8601 (e.g: 2018-05-30T09:39:52.000681Z), java_sql_timestamp (e.g: 2018-05-30 09:39:52.000681, useful for AWS Athena), and epoch.",
+                        "default": "double",
+                        "type": "string"
+                    },
+                    {
+                        "name": "json_date_key",
+                        "description": "Specify the name of the date field in output.",
+                        "default": "date",
+                        "type": "string"
+                    },
+                    {
+                        "name": "raw_message_key",
+                        "description": "use a raw message key for the message.",
+                        "default": null,
+                        "type": "string"
+                    }
+                ],
+                "networking": [
+                    {
+                        "name": "net.dns.mode",
+                        "description": "Select the primary DNS connection type (TCP or UDP)",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "net.dns.resolver",
+                        "description": "Select the primary DNS resolver type (LEGACY or ASYNC)",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "net.dns.prefer_ipv4",
+                        "description": "Prioritize IPv4 DNS results when trying to establish a connection",
+                        "default": "false",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "net.keepalive",
+                        "description": "Enable or disable Keepalive support",
+                        "default": "true",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "net.keepalive_idle_timeout",
+                        "description": "Set maximum time allowed for an idle Keepalive connection",
+                        "default": "30s",
+                        "type": "time"
+                    },
+                    {
+                        "name": "net.io_timeout",
+                        "description": "Set maximum time a connection can stay idle while assigned",
+                        "default": "0s",
+                        "type": "time"
+                    },
+                    {
+                        "name": "net.connect_timeout",
+                        "description": "Set maximum time allowed to establish a connection, this time includes the TLS handshake",
+                        "default": "10s",
+                        "type": "time"
+                    },
+                    {
+                        "name": "net.connect_timeout_log_error",
+                        "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message",
+                        "default": "true",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "net.source_address",
+                        "description": "Specify network address to bind for data traffic",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "net.keepalive_max_recycle",
+                        "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                        "default": "2000",
+                        "type": "integer"
                     }
                 ]
             }
@@ -8291,6 +9811,12 @@
                         "description": "Metric dimensions is a list of lists. If you have only one list of dimensions, put the values as a comma seperated string. If you want to put list of lists, use the list as semicolon seperated strings. If your value is 'd1,d2;d3', we will consider it as [[d1, d2],[d3]].",
                         "default": null,
                         "type": "string"
+                    },
+                    {
+                        "name": "profile",
+                        "description": "AWS Profile name. AWS Profiles can be configured with AWS CLI and are usually stored in $HOME/.aws/ directory.",
+                        "default": null,
+                        "type": "string"
                     }
                 ]
             }
@@ -8366,6 +9892,12 @@
                         "description": "Immediately retry failed requests to AWS services once. This option does not affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which may help improve throughput when there are transient/random networking issues.",
                         "default": "true",
                         "type": "boolean"
+                    },
+                    {
+                        "name": "profile",
+                        "description": "AWS Profile name. AWS Profiles can be configured with AWS CLI and are usually stored in $HOME/.aws/ directory.",
+                        "default": null,
+                        "type": "string"
                     }
                 ]
             }
@@ -8435,6 +9967,12 @@
                         "description": "Immediately retry failed requests to AWS services once. This option does not affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which may help improve throughput when there are transient/random networking issues.",
                         "default": "true",
                         "type": "boolean"
+                    },
+                    {
+                        "name": "profile",
+                        "description": "AWS Profile name. AWS Profiles can be configured with AWS CLI and are usually stored in $HOME/.aws/ directory.",
+                        "default": null,
+                        "type": "string"
                     }
                 ]
             }
@@ -8542,9 +10080,21 @@
                         "type": "space delimited strings (minimum 1)"
                     },
                     {
-                        "name": "uri",
+                        "name": "metrics_uri",
                         "description": "Specify an optional HTTP URI for the target OTel endpoint.",
                         "default": "/v1/metrics",
+                        "type": "string"
+                    },
+                    {
+                        "name": "logs_uri",
+                        "description": "Specify an optional HTTP URI for the target OTel endpoint.",
+                        "default": "/v1/logs",
+                        "type": "string"
+                    },
+                    {
+                        "name": "traces_uri",
+                        "description": "Specify an optional HTTP URI for the target OTel endpoint.",
+                        "default": "/v1/traces",
                         "type": "string"
                     },
                     {
@@ -8552,6 +10102,18 @@
                         "description": "Specify if the response paylod should be logged or not",
                         "default": "true",
                         "type": "boolean"
+                    },
+                    {
+                        "name": "batch_size",
+                        "description": "Set the maximum number of log records to be flushed at a time",
+                        "default": "1000",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "compress",
+                        "description": "Set payload compression mechanism. Option available is 'gzip'",
+                        "default": null,
+                        "type": "string"
                     }
                 ],
                 "networking": [
@@ -8866,6 +10428,48 @@
                         "type": "string"
                     },
                     {
+                        "name": "aws_auth",
+                        "description": "Enable AWS SigV4 authentication",
+                        "default": "false",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "aws_service",
+                        "description": "AWS destination service code, used by SigV4 authentication",
+                        "default": "aps",
+                        "type": "string"
+                    },
+                    {
+                        "name": "aws_region",
+                        "description": "AWS region of your service",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "aws_sts_endpoint",
+                        "description": "Custom endpoint for the AWS STS API, used with the `aws_role_arn` option",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "aws_role_arn",
+                        "description": "ARN of an IAM role to assume (ex. for cross account access)",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "aws_external_id",
+                        "description": "Specify an external ID for the STS API, can be used with the `aws_role_arn` parameter if your role requires an external ID.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "aws_profile",
+                        "description": "AWS Profile name. AWS Profiles can be configured with AWS CLI and are usuallystored in $HOME/.aws/ directory.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
                         "name": "header",
                         "description": "Add a HTTP header key/value pair. Multiple headers can be set",
                         "default": null,
@@ -9023,6 +10627,18 @@
                         "type": "integer"
                     },
                     {
+                        "name": "aws_shared_credentials_file",
+                        "description": "Path to the AWS shared credentials file.",
+                        "default": "",
+                        "type": "string"
+                    },
+                    {
+                        "name": "aws_config_file",
+                        "description": "Path to the AWS default configuration file.",
+                        "default": "",
+                        "type": "string"
+                    },
+                    {
                         "name": "json_date_format",
                         "description": "Specify the format of the date, supported formats: double, iso8601 (e.g: 2018-05-30T09:39:52.000681Z), java_sql_timestamp (e.g: 2018-05-30 09:39:52.000681, useful for AWS Athena), and epoch.",
                         "default": null,
@@ -9107,6 +10723,12 @@
                         "type": "string"
                     },
                     {
+                        "name": "store_dir_limit_size",
+                        "description": "S3 plugin has its own buffering system with files in the `store_dir`. Use the `store_dir_limit_size` to limit the amount of data S3 buffers in the `store_dir` to limit disk usage. If the limit is reached, data will be discarded. Default is 0 which means unlimited.",
+                        "default": null,
+                        "type": "size"
+                    },
+                    {
                         "name": "s3_key_format",
                         "description": "Format string for keys in S3. This option supports strftime time formatters and a syntax for selecting parts of the Fluent log tag using a syntax inspired by the rewrite_tag filter. Add $TAG in the format string to insert the full log tag; add $TAG[0] to insert the first part of the tag in the s3 key. The tag is split into “parts” using the characters specified with the s3_key_format_tag_delimiters option. Add $INDEX to enable sequential indexing for file names. Adding $INDEX will prevent random string being added to end of keywhen $UUID is not provided. See the in depth examples and tutorial in the documentation.",
                         "default": "/fluent-bit-logs/$TAG/%Y/%m/%d/%H/%M/%S",
@@ -9139,7 +10761,7 @@
                     {
                         "name": "preserve_data_ordering",
                         "description": "Normally, when an upload request fails, there is a high chance for the last received chunk to be swapped with a later chunk, resulting in data shuffling. This feature prevents this shuffling by using a queue logic for uploads.",
-                        "default": "false",
+                        "default": "true",
                         "type": "boolean"
                     },
                     {
@@ -9163,6 +10785,12 @@
                     {
                         "name": "storage_class",
                         "description": "Specify the storage class for S3 objects. If this option is not specified, objects will be stored with the default 'STANDARD' storage class.",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "profile",
+                        "description": "AWS Profile name. AWS Profiles can be configured with AWS CLI and are usually stored in $HOME/.aws/ directory.",
                         "default": null,
                         "type": "string"
                     }
@@ -9283,6 +10911,107 @@
                         "description": "Hostname to be used for TLS SNI extension",
                         "default": null,
                         "type": "string"
+                    }
+                ]
+            }
+        },
+        {
+            "type": "output",
+            "name": "vivo_exporter",
+            "description": "Vivo Exporter",
+            "properties": {
+                "options": [
+                    {
+                        "name": "host",
+                        "description": "Host Address",
+                        "default": "",
+                        "type": "string"
+                    },
+                    {
+                        "name": "port",
+                        "description": "host Port",
+                        "default": "0",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "empty_stream_on_read",
+                        "description": "If enabled, when an HTTP client consumes the data from a stream, the queue content will be removed",
+                        "default": "off",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "stream_queue_size",
+                        "description": "Specify the maximum queue size per stream. Each specific stream for logs, metrics and traces can hold up to 'stream_queue_size' bytes.",
+                        "default": "20M",
+                        "type": "size"
+                    },
+                    {
+                        "name": "http_cors_allow_origin",
+                        "description": "Specify the value for the HTTP Access-Control-Allow-Origin header (CORS)",
+                        "default": null,
+                        "type": "string"
+                    }
+                ],
+                "networking": [
+                    {
+                        "name": "net.dns.mode",
+                        "description": "Select the primary DNS connection type (TCP or UDP)",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "net.dns.resolver",
+                        "description": "Select the primary DNS resolver type (LEGACY or ASYNC)",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "net.dns.prefer_ipv4",
+                        "description": "Prioritize IPv4 DNS results when trying to establish a connection",
+                        "default": "false",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "net.keepalive",
+                        "description": "Enable or disable Keepalive support",
+                        "default": "true",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "net.keepalive_idle_timeout",
+                        "description": "Set maximum time allowed for an idle Keepalive connection",
+                        "default": "30s",
+                        "type": "time"
+                    },
+                    {
+                        "name": "net.io_timeout",
+                        "description": "Set maximum time a connection can stay idle while assigned",
+                        "default": "0s",
+                        "type": "time"
+                    },
+                    {
+                        "name": "net.connect_timeout",
+                        "description": "Set maximum time allowed to establish a connection, this time includes the TLS handshake",
+                        "default": "10s",
+                        "type": "time"
+                    },
+                    {
+                        "name": "net.connect_timeout_log_error",
+                        "description": "On connection timeout, specify if it should log an error. When disabled, the timeout is logged as a debug message",
+                        "default": "true",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "net.source_address",
+                        "description": "Specify network address to bind for data traffic",
+                        "default": null,
+                        "type": "string"
+                    },
+                    {
+                        "name": "net.keepalive_max_recycle",
+                        "description": "Set maximum number of times a keepalive connection can be used before it is retired.",
+                        "default": "2000",
+                        "type": "integer"
                     }
                 ]
             }

--- a/service_port.go
+++ b/service_port.go
@@ -1,6 +1,7 @@
 package fluentbitconfig
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/calyptia/go-fluentbit-config/v2/networking"
@@ -61,6 +62,16 @@ func (c *Config) ServicePorts() ServicePorts {
 
 	lookup := func(kind SectionKind, plugins Plugins) {
 		for _, plugin := range plugins {
+			err := ValidateSection(kind, plugin.Properties)
+			if errors.Is(err, ErrMissingName) {
+				continue
+			}
+
+			var e *UnknownPluginError
+			if errors.As(err, &e) {
+				continue
+			}
+
 			if plugin.Name == "forward" && plugin.Properties.Has("unix_path") {
 				continue
 			}

--- a/service_port_test.go
+++ b/service_port_test.go
@@ -128,6 +128,9 @@ func TestConfig_ServicePorts(t *testing.T) {
 				name syslog
 				mode unix_tcp
 				port 4
+			[INPUT]
+				name does_not_exists
+				port 5
 		`, FormatClassic)
 		assert.NoError(t, err)
 		assert.Equal(t, nil, config.ServicePorts())

--- a/validator.go
+++ b/validator.go
@@ -1,7 +1,6 @@
 package fluentbitconfig
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -9,8 +8,6 @@ import (
 
 	"github.com/calyptia/go-fluentbit-config/v2/property"
 )
-
-var ErrMissingName = errors.New("missing name property")
 
 // Validate with the default schema.
 func (c Config) Validate() error {
@@ -79,7 +76,7 @@ func ValidateSectionWithSchema(kind SectionKind, props property.Properties, sche
 
 	section, ok := schema.findSection(kind, name)
 	if !ok {
-		return fmt.Errorf("%s: unknown plugin %q", kind, name)
+		return NewUnknownPluginError(kind, name)
 	}
 
 	for _, p := range props {


### PR DESCRIPTION
Skip getting the service port from an unknown plugin.

This PR comes because I tried to use the [ServicePorts()](https://github.com/calyptia/go-fluentbit-config/blob/8877733d9a865d54a7f5790565a10eb66fe1d810/service_port.go#L41) method on Cloud, but it detected an unknown plugin and extracted its port like so:

```
[INPUT]
  name nutella
  port 1234
```

While this should not happen.